### PR TITLE
Add support for polarization data

### DIFF
--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1699,7 +1699,7 @@ class Data(DataContainer):
         if nperiods > 1:
             last_period = self.time_max - time_s * (nperiods - 1)
             # Discard last period if smaller than 3% of the bg period
-            if last_period < time_s * 0.03:
+            if last_period < time_s * 0.06:
                 nperiods -= 1
         return int(nperiods)
 

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1763,6 +1763,10 @@ class Data(DataContainer):
         else:
             th_us = self._get_bg_th_arrays(tail_min_us, nperiods)
 
+        # Note: histogram bins are half-open, e.g. [a, b)
+        bins = ((np.arange(nperiods + 1) * time_s + self.time_min) /
+                self.clk_p)
+
         Lim, Ph_p = [], []
         BG, BG_err = [], []
         Th_us = []
@@ -1770,13 +1774,17 @@ class Data(DataContainer):
             masks = {sel: self.get_ph_mask(ich, ph_sel=sel)
                      for sel in self.ph_streams}
 
-            bins = ((np.arange(nperiods + 1) * time_s + self.time_min) /
-                    self.clk_p)
-            # Note: histogram bins are half-open, e.g. [a, b)
             counts, _ = np.histogram(ph_ch, bins=bins)
             lim, ph_p = [], []
             bg = {sel: np.zeros(nperiods) for sel in self.ph_streams}
             bg_err = {sel: np.zeros(nperiods) for sel in self.ph_streams}
+            if ph_ch.size == 0:
+                Lim.append(lim)
+                Ph_p.append(ph_p)
+                BG.append(bg)
+                BG_err.append(bg_err)
+                Th_us.append(th_us)
+                break
             i1 = 0
             for ip in range(nperiods):
                 i0 = i1

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1020,6 +1020,10 @@ class Data(DataContainer):
         return self._get_tuple_multich('det_donor_accept')
 
     @property
+    def _det_p_s_pol_multich(self):
+        return self._get_tuple_multich('det_p_s_pol')
+
+    @property
     def _aex_fraction(self):
         """Proportion of Aex period versus Dex + Aex."""
         assert self.alternated

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1806,7 +1806,7 @@ class Data(DataContainer):
                     else:
                         ph_i_sel = ph_i[masks[sel][i0:i1]]
 
-                    if ph_i_sel.size > 0:
+                    if ph_i_sel.size > 10:
                         if bg_auto_th:
                             _bg, _ = fun(ph_i_sel, **auto_th_kwargs)
                             th_us[sel][ip] = 1e6 * F_bg / _bg

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -445,6 +445,8 @@ def _usalex_apply_period_1ch(d, delete_ph_t=True, remove_d_em_a_ex=False,
     valid_det = d_ch_mask_t + a_ch_mask_t
 
     # Build masks for excitation windows
+    if 'offset' in d:
+        ph_times_t -= d.offset
     d_ex_mask_t = _select_range(ph_times_t, d.alex_period, D_ON)
     a_ex_mask_t = _select_range(ph_times_t, d.alex_period, A_ON)
     # Safety check: each ph is either D or A ex (not both)
@@ -461,8 +463,6 @@ def _usalex_apply_period_1ch(d, delete_ph_t=True, remove_d_em_a_ex=False,
     a_ex = a_ex_mask_t[DexAex_mask]
     assert d_ex.sum() == d_ex_mask_t.sum()
     assert a_ex.sum() == a_ex_mask_t.sum()
-    if 'offset' in d:
-        ph_times -= d.offset
 
     if remove_d_em_a_ex:
         # Removes donor-ch photons during acceptor excitation

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -335,7 +335,13 @@ def photon_hdf5(filename, ondisk=False, require_setup=True):
 
     h5file = tables.open_file(filename)
     # make sure the file is valid
-    phc.hdf5.assert_valid_photon_hdf5(h5file, require_setup=require_setup)
+    if version.startswith(u'0.4'):
+        phc.v04.hdf5.assert_valid_photon_hdf5(h5file,
+                                              require_setup=require_setup,
+                                              strict_description=False)
+    else:
+        phc.hdf5.assert_valid_photon_hdf5(h5file, require_setup=require_setup,
+                                          strict_description=False)
     # Create the data container
     h5data = h5file.root
     d = Data(fname=filename, data_file=h5data._v_file)

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -337,11 +337,11 @@ def photon_hdf5(filename, ondisk=False, require_setup=True, validate=False):
 
     h5file = tables.open_file(filename)
     # make sure the file is valid
-    if version.startswith(u'0.4'):
+    if validate and version.startswith(u'0.4'):
         phc.v04.hdf5.assert_valid_photon_hdf5(h5file,
                                               require_setup=require_setup,
                                               strict_description=False)
-    else:
+    elif validate:
         phc.hdf5.assert_valid_photon_hdf5(h5file, require_setup=require_setup,
                                           strict_description=False)
     # Create the data container

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -114,7 +114,7 @@ def _get_measurement_specs(ph_data, setup):
             meas_type += '-2pol'
         # Check consistency of polarization specs
         if meas_specs is not None:
-            det_specs = meas_specs['detectors_specs']
+            det_specs = meas_specs.detectors_specs
             if setup.num_polarization_ch.read() == 1:
                 if all('polarization_ch%i' in det_specs for i in (1, 2)):
                     msg = ("The field `/setup/num_polarization_ch` indicates "

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -307,7 +307,7 @@ def _photon_hdf5_multich(h5data, data, ondisk=True):
                          loadspecs=False)
 
 
-def photon_hdf5(filename, ondisk=False, require_setup=True):
+def photon_hdf5(filename, ondisk=False, require_setup=True, validate=False):
     """Load a data file saved in Photon-HDF5 format version 0.3 or higher.
 
     Photon-HDF5 is a format for a wide range of timestamp-based
@@ -323,6 +323,8 @@ def photon_hdf5(filename, ondisk=False, require_setup=True):
             have a setup group or won't be loaded. If False, accept files
             with missing setup group. Use False only for testing or
             DCR files.
+        validate (bool): if True validate the Photon-HDF5 file on loading.
+            If False skip any validation.
 
     Returns:
         :class:`fretbursts.burstlib.Data` object containing the data.

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -266,7 +266,7 @@ def _photon_hdf5_multich(h5data, data, ondisk=True):
                          loadspecs=False)
 
 
-def photon_hdf5(filename, ondisk=False, strict=False):
+def photon_hdf5(filename, ondisk=False, require_setup=True):
     """Load a data file saved in Photon-HDF5 format version 0.3 or higher.
 
     Photon-HDF5 is a format for a wide range of timestamp-based
@@ -278,6 +278,10 @@ def photon_hdf5(filename, ondisk=False, strict=False):
         filename (str or pathlib.Path): path of the data file to be loaded.
         ondisk (bool): if True, do not load the timestamps in memory
             using instead references to the HDF5 arrays. Default False.
+        require_setup (bool): if True (default) the input file need to
+            have a setup group or won't be loaded. If False, accept files
+            with missing setup group. Use False only for testing or
+            DCR files.
 
     Returns:
         :class:`fretbursts.burstlib.Data` object containing the data.
@@ -289,6 +293,9 @@ def photon_hdf5(filename, ondisk=False, strict=False):
         return loader_legacy.hdf5(filename)
 
     h5file = tables.open_file(filename)
+    # make sure the file is valid
+    phc.hdf5.assert_valid_photon_hdf5(h5file, require_setup=require_setup)
+    # Create the data container
     h5data = h5file.root
     d = Data(fname=filename, data_file=h5data._v_file)
 

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -218,14 +218,15 @@ def _compute_acceptor_emission_mask(data, ich, ondisk):
     donor, accept = data._det_donor_accept_multich[ich]
 
     # Remove counts not associated with D or A channels
-    num_detectors = len(np.unique(data.detectors[ich]))
+    det_ich = data.detectors[ich][:]  # load the data in case ondisk = True
+    num_detectors = len(np.unique(det_ich))
     if not ondisk and num_detectors > donor.size + accept.size:
-        mask = (_selection_mask(data.detectors[ich], donor) +
-                _selection_mask(data.detectors[ich], accept))
-        data.detectors[ich] = data.detectors[ich][mask]
-        data.ph_times_m[ich] = data.ph_times_m[ich][mask]
+        mask = (_selection_mask(det_ich, donor) +
+                _selection_mask(det_ich, accept))
+        data.detectors[ich] = det_ich[mask]
+        data.ph_times_m[ich] = det_ich[mask]
         if 'nanotimes' in data:
-            data.nanotimes[ich] = data.nanotimes[ich][mask]
+            data.nanotimes[ich] = data.nanotimes[ich][:][mask]
 
     # From `detectors` compute boolean mask `A_em`
     if not ondisk and donor.size == 1 and 0 in (accept, donor):
@@ -235,9 +236,9 @@ def _compute_acceptor_emission_mask(data, ich, ondisk):
         if accept == 0:
             np.logical_not(data.A_em[ich], out=data.A_em[ich])
     else:
-        # Create the boolean mask
+        # Create the boolean mask as a new array
         _append_data_ch(data, 'A_em',
-                        _selection_mask(data.detectors[ich][:], accept))
+                        _selection_mask(det_ich, accept))
 
 
 def _photon_hdf5_1ch(h5data, data, ondisk=False, nch=1, ich=0, loadspecs=True):

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -546,7 +546,7 @@ def nsalex_apply_period(d, delete_ph_t=True):
 
     *See also:* :func:`alex_apply_period`.
     """
-    ich = 0
+    ich = 0   # we only support single-spot here
     donor_ch, accept_ch = d._det_donor_accept_multich[ich]
     D_ON_multi, A_ON_multi = d._D_ON_multich[ich], d._A_ON_multich[ich]
     D_ON = [(D_ON_multi[i], D_ON_multi[i+1]) for i in range(0, len(D_ON_multi), 2)]
@@ -572,8 +572,8 @@ def nsalex_apply_period(d, delete_ph_t=True):
     mask = da_ch_mask_t * ex_mask_t  # logical AND
 
     # Apply selection to timestamps and nanotimes
-    ph_times = d.ph_times_t[ich][mask]
-    nanotimes = d.nanotimes_t[ich][mask]
+    ph_times = d.ph_times_t[ich][:][mask]
+    nanotimes = d.nanotimes_t[ich][:][mask]
 
     # Apply selection to the emission masks
     d_em = d_ch_mask_t[mask]

--- a/fretbursts/phtools/burstsearch.py
+++ b/fretbursts/phtools/burstsearch.py
@@ -655,8 +655,8 @@ class BurstsGap(Bursts):
 
     def __iter__(self):
         for bdata in self.data:
-           yield BurstGap(bdata[0], bdata[1], bdata[2], bdata[3],
-                          bdata[4], bdata[5])
+            yield BurstGap(bdata[0], bdata[1], bdata[2], bdata[3],
+                           bdata[4], bdata[5])
 
     @property
     def gap(self):


### PR DESCRIPTION
This PR allows loading files that have detection path split in 2 spectral bands and 2 polarization bands (4 detectors).

This requires Photon-HDF5 0.5 and [phconvert 0.8.1](https://github.com/Photon-HDF5/phconvert/releases) (commit https://github.com/Photon-HDF5/phconvert/commit/1be9aeda88a053acee5135c76891ae6fceb103f2 or later).

This PR was motivated by #12. 

~~This code is untested so far.~~

Code tested and ready for merging.