### PR TITLE
replace mpl.normpdf with scipy.stats.norm.pdf 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - conda create -n conda_test_env --yes python=$TRAVIS_PYTHON_VERSION
     - source activate conda_test_env
     - conda install --yes scipy matplotlib cython numba pytest nbconvert ipykernel ipywidgets seaborn
-    - conda install pandas=0.25.2
+    - conda install pandas<=0.24.0
     - conda config --append channels conda-forge
     - conda install --yes lmfit
     - conda install --yes phconvert

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - conda create -n conda_test_env --yes python=$TRAVIS_PYTHON_VERSION
     - source activate conda_test_env
     - conda install --yes scipy matplotlib cython numba pytest nbconvert ipykernel ipywidgets seaborn
-    - conda install -- yes pandas=0.25.2
+    - conda install pandas=0.25.2
     - conda config --append channels conda-forge
     - conda install --yes lmfit
     - conda install --yes phconvert

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,5 @@ script:
     - python ../fretbursts/tests/nbrun.py --exclude-list dev/exclude-py27.txt .
 
 sudo: false
+
+# Travis-CI.com migration

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - conda create -n conda_test_env --yes python=$TRAVIS_PYTHON_VERSION
     - source activate conda_test_env
     - conda install --yes scipy matplotlib cython numba pytest nbconvert ipykernel ipywidgets seaborn
-    - conda install pandas=0.24.0
+    - conda install --yes pandas=0.24.0
     - conda config --append channels conda-forge
     - conda install --yes lmfit
     - conda install --yes phconvert

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: xenial
 python:
     - "3.6"
     - "3.7"
+    - "3.8"
 
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
 install:
     - conda create -n conda_test_env --yes python=$TRAVIS_PYTHON_VERSION
     - source activate conda_test_env
-    - conda install --yes scipy pandas matplotlib cython numba pytest nbconvert ipykernel ipywidgets seaborn
+    - conda install --yes scipy matplotlib cython numba pytest nbconvert ipykernel ipywidgets seaborn
+    - conda install -- yes pandas=0.25.2
     - conda config --append channels conda-forge
     - conda install --yes lmfit
     - conda install --yes phconvert

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - conda create -n conda_test_env --yes python=$TRAVIS_PYTHON_VERSION
     - source activate conda_test_env
     - conda install --yes scipy matplotlib cython numba pytest nbconvert ipykernel ipywidgets seaborn
-    - conda install pandas<=0.24.0
+    - conda install pandas=0.24.0
     - conda config --append channels conda-forge
     - conda install --yes lmfit
     - conda install --yes phconvert

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda config --append channels conda-forge
   - "conda create -q -n test-environment python=%PYTHON_VERSION% pip scipy matplotlib lmfit cython numba nbconvert pytest ipykernel ipywidgets seaborn terminado"
   - activate test-environment
-  - conda install pandas=0.25.2
+  - conda install pandas<=0.24.0
   - conda install phconvert
   - python -m pip install --upgrade pip
   - pip install pybroom

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,9 @@ install:
   - conda update -q conda
   - conda info -a
   - conda config --append channels conda-forge
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% pip scipy pandas matplotlib lmfit cython numba nbconvert pytest ipykernel ipywidgets seaborn terminado"
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% pip scipy matplotlib lmfit cython numba nbconvert pytest ipykernel ipywidgets seaborn terminado"
   - activate test-environment
+  - conda install pandas=0.25.2
   - conda install phconvert
   - python -m pip install --upgrade pip
   - pip install pybroom

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda config --append channels conda-forge
   - "conda create -q -n test-environment python=%PYTHON_VERSION% pip scipy matplotlib lmfit cython numba nbconvert pytest ipykernel ipywidgets seaborn terminado"
   - activate test-environment
-  - conda install pandas<=0.24.0
+  - conda install pandas=0.24.0
   - conda install phconvert
   - python -m pip install --upgrade pip
   - pip install pybroom

--- a/fretbursts/burst_plot.py
+++ b/fretbursts/burst_plot.py
@@ -40,8 +40,8 @@ from itertools import cycle
 # Numeric imports
 import numpy as np
 from numpy import arange, r_
-from matplotlib.mlab import normpdf
-from scipy.stats import erlang
+#from matplotlib.mlab import normpdf
+from scipy.stats import (erlang, norm)
 from scipy.interpolate import UnivariateSpline
 
 # Graphics imports
@@ -1018,8 +1018,8 @@ def _fitted_E_plot(d, i=0, F=1, no_E=False, ax=None, show_model=True,
                 a2 = (1-a1)
             elif d.fit_E_res.shape[1] == 6:
                 m1, s1, a1, m2, s2, a2 = d.fit_E_res[i, :]
-            y1 = a1*normpdf(x, m1, s1)
-            y2 = a2*normpdf(x, m2, s2)
+            y1 = a1*norm.pdf(x, m1, s1)
+            y2 = a2*norm.pdf(x, m2, s2)
             ax2.plot(x, scale*y1, ls='--', lw=lw, alpha=alpha, color=color)
             ax2.plot(x, scale*y2, ls='--', lw=lw, alpha=alpha, color=color)
         if fillcolor is None:

--- a/fretbursts/burstlib_ext.py
+++ b/fretbursts/burstlib_ext.py
@@ -793,7 +793,7 @@ def join_data(d_list, gap=0):
             concatenate = Bursts.merge if name == 'mburst' else np.concatenate
 
             for ich in range(nch):
-                new_size = np.sum(np.fromiter((d.mburst[ich].num_bursts for d in d_list)))
+                new_size = sum(d.mburst[ich].num_bursts for d in d_list)
                 if new_size == 0:
                     continue  # -> No bursts in this ch
 
@@ -802,7 +802,7 @@ def join_data(d_list, gap=0):
                 assert new_d[name][ich].size == new_size
 
     # Set the background fields by concatenation along axis = 0
-    new_nperiods = np.sum(np.fromiter((d.nperiods for d in d_list)))
+    new_nperiods = sum(d.nperiods for d in d_list)
     for name in ('Lim', 'Ph_p'):
         if name in new_d:
             new_d.add(**{name: []})

--- a/fretbursts/burstlib_ext.py
+++ b/fretbursts/burstlib_ext.py
@@ -793,7 +793,7 @@ def join_data(d_list, gap=0):
             concatenate = Bursts.merge if name == 'mburst' else np.concatenate
 
             for ich in range(nch):
-                new_size = np.sum((d.mburst[ich].num_bursts for d in d_list))
+                new_size = np.sum(np.fromiter((d.mburst[ich].num_bursts for d in d_list)))
                 if new_size == 0:
                     continue  # -> No bursts in this ch
 
@@ -802,7 +802,7 @@ def join_data(d_list, gap=0):
                 assert new_d[name][ich].size == new_size
 
     # Set the background fields by concatenation along axis = 0
-    new_nperiods = np.sum((d.nperiods for d in d_list))
+    new_nperiods = np.sum(np.fromiter((d.nperiods for d in d_list)))
     for name in ('Lim', 'Ph_p'):
         if name in new_d:
             new_d.add(**{name: []})

--- a/fretbursts/fit/test_exp_fitting.py
+++ b/fretbursts/fit/test_exp_fitting.py
@@ -60,13 +60,5 @@ def test_expon_fit_histw(sample):
             (tau_fit, relative_error*100))
     assert relative_error < max_relative_error
 
-def test_normpdf(sample):
-    lambda_fit, resid, x_resid, size = expon_fit(sample, s_min=sample_min)
-    tau_fit = 1./lambda_fit
-    relative_error = np.abs(tau_fit-sample_tau)/sample_tau
-    print('\n [normpdf] Fit (tau): %.2f  - Relative error: %.2f %%' % \
-            (tau_fit, relative_error*100))
-    assert relative_error < max_relative_error
-
 if __name__ == '__main__':
     pytest.main("-x -v -s fretbursts/fit/test_exp_fitting.py")

--- a/fretbursts/fit/test_exp_fitting.py
+++ b/fretbursts/fit/test_exp_fitting.py
@@ -60,5 +60,13 @@ def test_expon_fit_histw(sample):
             (tau_fit, relative_error*100))
     assert relative_error < max_relative_error
 
+def test_normpdf(sample):
+    lambda_fit, resid, x_resid, size = expon_fit(sample, s_min=sample_min)
+    tau_fit = 1./lambda_fit
+    relative_error = np.abs(tau_fit-sample_tau)/sample_tau
+    print('\n [normpdf] Fit (tau): %.2f  - Relative error: %.2f %%' % \
+            (tau_fit, relative_error*100))
+    assert relative_error < max_relative_error
+
 if __name__ == '__main__':
     pytest.main("-x -v -s fretbursts/fit/test_exp_fitting.py")

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -313,7 +313,7 @@ def test_bg_calc(data):
     data.calc_bg(bg.exp_fit, time_s=30, tail_min_us='auto', F_bg=1.7,
                  fit_allph=False)
     streams = [s for s in data.ph_streams if s != Ph_sel('all')]
-    bg_t = [np.sum(data.bg[s][ich] for s in streams) for ich in range(data.nch)]
+    bg_t = [sum(data.bg[s][ich] for s in streams) for ich in range(data.nch)]
     assert list_array_equal(data.bg[Ph_sel('all')], bg_t)
 
 
@@ -1175,7 +1175,7 @@ def test_normpdf():
     x = np.linspace(norm.ppf(0.01), norm.ppf(0.99), 100)
     mu = 0
     sigma = 1.1
-    
+
     assert np.allclose(normpdf(x, mu=mu, sigma=sigma), norm.pdf(x, loc=mu, scale=sigma))
 
 if __name__ == '__main__':

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -81,7 +81,7 @@ def load_fake_pax():
 
 x = np.linspace(norm.ppf(0.01), norm.ppf(0.99), 100)
 
-def normpdf(x, mu=0, sigma=1.):
+def normpdf(x, mu=0, sigma=0):
     """Return the normal pdf evaluated at `x`."""
     if mu != 1 and sigma != 1:
         u = (x-mu)/sigma
@@ -1172,7 +1172,7 @@ def test_collapse(data_8ch):
         else:
             assert np.allclose(dc1[name][0], dc2[name][0])
 
-def test_normpdf()
+def test_normpdf():
     assert np.allclose(normpdf(x, mu=mu, sigma=sigma), norm.pdf(x, loc=mu, scale=sigma))
 
 if __name__ == '__main__':

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -15,6 +15,7 @@ from builtins import range, zip
 from collections import namedtuple
 import pytest
 import numpy as np
+from scipy.stats import norm
 
 try:
     import matplotlib
@@ -78,6 +79,14 @@ def load_fake_pax():
     d.burst_search(L=10, m=10, F=6, pax=True)
     return d
 
+x = np.linspace(norm.ppf(0.01), norm.ppf(0.99), 100)
+
+def normpdf(x, mu=0, sigma=1.):
+    """Return the normal pdf evaluated at `x`."""
+    if mu != 1 and sigma != 1:
+        u = (x-mu)/sigma
+        y = 1/(np.sqrt(2*np.pi)*sigma)*np.exp(-u*u/2)
+    return y
 
 @pytest.fixture(scope="module", params=[
                                     load_dataset_1ch,
@@ -1162,6 +1171,9 @@ def test_collapse(data_8ch):
             assert dc1.mburst[0] == dc2.mburst[0]
         else:
             assert np.allclose(dc1[name][0], dc2[name][0])
+
+def test_normpdf()
+    assert np.allclose(normpdf(x, mu=mu, sigma=sigma), norm.pdf(x, loc=mu, scale=sigma))
 
 if __name__ == '__main__':
     pytest.main("-x -v fretbursts/tests/test_burstlib.py")

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -1173,6 +1173,8 @@ def test_collapse(data_8ch):
             assert np.allclose(dc1[name][0], dc2[name][0])
 
 def test_normpdf():
+    mu = 0
+    sigma = 1.1
     assert np.allclose(normpdf(x, mu=mu, sigma=sigma), norm.pdf(x, loc=mu, scale=sigma))
 
 if __name__ == '__main__':

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -79,10 +79,9 @@ def load_fake_pax():
     d.burst_search(L=10, m=10, F=6, pax=True)
     return d
 
-x = np.linspace(norm.ppf(0.01), norm.ppf(0.99), 100)
-
 def normpdf(x, mu=0, sigma=0):
     """Return the normal pdf evaluated at `x`."""
+    x = np.linspace(norm.ppf(0.01), norm.ppf(0.99), 100)
     if mu != 1 and sigma != 1:
         u = (x-mu)/sigma
         y = 1/(np.sqrt(2*np.pi)*sigma)*np.exp(-u*u/2)
@@ -1173,8 +1172,6 @@ def test_collapse(data_8ch):
             assert np.allclose(dc1[name][0], dc2[name][0])
 
 def test_normpdf():
-    mu = 0
-    sigma = 1.1
     assert np.allclose(normpdf(x, mu=mu, sigma=sigma), norm.pdf(x, loc=mu, scale=sigma))
 
 if __name__ == '__main__':

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -1172,6 +1172,10 @@ def test_collapse(data_8ch):
             assert np.allclose(dc1[name][0], dc2[name][0])
 
 def test_normpdf():
+    x = np.linspace(norm.ppf(0.01), norm.ppf(0.99), 100)
+    mu = 0
+    sigma = 1.1
+    
     assert np.allclose(normpdf(x, mu=mu, sigma=sigma), norm.pdf(x, loc=mu, scale=sigma))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Attempting to fix the issue reported in [#30](https://github.com/OpenSMFS/FRETBursts/issues/30).

Error seems to be resolved, but I now get the following AttributeError:

`Traceback (most recent call last)`
`<ipython-input-2-e7d4478a60c7> in <module>`
`----> 1 from fretbursts import *`

`AttributeError: module 'fretbursts' has no attribute 'bg_cache'`

I see that the checks have failed, and I am doing my best to understand them. The offending code returns a `ValueError` that does not arise from any changes I have made. 