### PR TITLE
Technical Repeat Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,19 @@ jobs:
         run: |
           wget -N http://files.figshare.com/2182604/12d_New_30p_320mW_steer_3.hdf5
           wget -N http://files.figshare.com/2182601/0023uLRpitc_NTP_20dT_0.5GndCl.hdf5
+          wget -N https://zenodo.org/record/5902313/files/HP3_TE150_SPC630.hdf5
+          wget -N https://zenodo.org/record/5902313/files/HP3_TE200_SPC630.hdf5
+          wget -N https://zenodo.org/record/5902313/files/HP3_TE250_SPC630.hdf5
+          wget -N https://zenodo.org/record/5902313/files/HP3_TE300_SPC630.hdf5
       - name: Downlaod files Windows
         if: runner.os == 'Windows'
         run: |
           curl.exe --output 2182604/12d_New_30p_320mW_steer_3.hdf5 --url http://files.figshare.com/2182604/12d_New_30p_320mW_steer_3.hdf5
           curl.exe --output 0023uLRpitc_NTP_20dT_0.5GndCl.hdf5 --url http://files.figshare.com/2182601/0023uLRpitc_NTP_20dT_0.5GndCl.hdf5
+          curl.exe --output HP3_TE150_SPC630.hdf5 --url https://zenodo.org/record/5902313/files/HP3_TE150_SPC630.hdf5
+          curl.exe --output HP3_TE200_SPC630.hdf5 --url https://zenodo.org/record/5902313/files/HP3_TE200_SPC630.hdf5
+          curl.exe --output HP3_TE250_SPC630.hdf5 --url https://zenodo.org/record/5902313/files/HP3_TE250_SPC630.hdf5
+          curl.exe --output HP3_TE300_SPC630.hdf5 --url https://zenodo.org/record/5902313/files/HP3_TE300_SPC630.hdf5
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Windows 3.6 Oddities

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ FRETBursts
 
 [![DOI](https://zenodo.org/badge/5991/tritemio/FRETBursts.svg)](https://zenodo.org/badge/latestdoi/5991/tritemio/FRETBursts)
 [![Tests](https://github.com/OpenSMFS/FRETBursts/actions/workflows/tests.yml/badge.svg)](https://github.com/OpenSMFS/FRETBursts/actions)
+[![Documentation Status](https://readthedocs.org/projects/fretbursts/badge/?version=latest)](https://fretbursts.readthedocs.io/en/latest/?badge=latest)
 > *Quick links: [Reference documentation](http://fretbursts.readthedocs.org/), [FRETBursts tutorials](https://github.com/OpenSMFS/FRETBursts_notebooks#fretbursts-notebooks), [FRETBursts paper](http://dx.doi.org/10.1101/039198)*
 
 Latest News

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -11,6 +11,9 @@ Version 0.7.1 (unreleased)
 - More fixes for PIE file with polarization, thanks to Christian Gebhardt 
   for reporting the problem and suggesting solutions 
   (`issue <https://github.com/OpenSMFS/FRETBursts/issues/25>`__)
+- Passing list of strings to `loader.photon_hdf5()` loads each file into the same data object as an excitation spot.
+- dplot function keyword argument `i=None` now plots concatenated data from all excitation spots. Does not apply to trace-based plots
+- Fitter attributes relating to fit values now have parallel attributes ending in `_tot` which are for concatentated data across all spots.
 
 
 Version 0.7 (Jul. 2018)

--- a/fretbursts/background.py
+++ b/fretbursts/background.py
@@ -225,9 +225,9 @@ def fit_varying_min_delta_ph(d, min_delta_ph_list, bg_fit_fun=exp_fit,
         (nch, nperiods, len(min_delta_ph_list)).
     """
 
-    BG = np.zeros((d.nch, d.nperiods, np.size(min_delta_ph_list)))
+    BG = np.zeros((d.nch, d.nperiods.max(), np.size(min_delta_ph_list)))
     BG_err = np.zeros_like(BG)
-    BG[:], BG_err[:] = None, None
+    BG[:], BG_err[:] = np.nan, np.nan
 
     for ich in range(d.nch):
         for period, ph in enumerate(

--- a/fretbursts/burst_plot.py
+++ b/fretbursts/burst_plot.py
@@ -33,6 +33,7 @@ For more examples refer to
 
 import warnings
 from itertools import cycle
+from collections.abc import Iterable
 
 # Numeric imports
 import numpy as np
@@ -456,7 +457,7 @@ def timetrace_single(d, i=0, binwidth=1e-3, bins=None, tmin=0, tmax=200,
             plt.ylim(bottom=-100)
         _plot_status['timetrace_single'] = {'autoscale': False}
 
-
+# do not concatenate, timetrace should always be shown per channel
 def timetrace(d, i=0, binwidth=1e-3, bins=None, tmin=0, tmax=200,
               bursts=False, burst_picker=True, scroll=False,
               show_rate_th=True, F=None, rate_th_style={'label': None},
@@ -556,7 +557,7 @@ def ratetrace_single(d, i=0, m=None, max_num_ph=1e6, tmin=0, tmax=200,
     iph1 = np.searchsorted(ph_times, tmin_clk)
     iph2 = np.searchsorted(ph_times, tmax_clk)
     if iph2 - iph1 > max_num_ph:
-        iph2 = iph1 + max_num_ph
+        iph2 = iph1 + int(max_num_ph)
         tmax = ph_times[iph2] * d.clk_p
         warnings.warn(('Max number of photons reached in ratetrace_single().'
                        '\n    tmax is reduced to %ds. To plot a wider '
@@ -596,7 +597,7 @@ def ratetrace_single(d, i=0, m=None, max_num_ph=1e6, tmin=0, tmax=200,
             plt.ylim(bottom=-100)
         _plot_status['ratetrace_single'] = {'autoscale': False}
 
-
+# same, must be plotted per channel always
 def ratetrace(d, i=0, m=None, max_num_ph=1e6, tmin=0, tmax=200,
               bursts=False, burst_picker=True, scroll=False,
               show_rate_th=True, F=None, rate_th_style={'label': None},
@@ -674,10 +675,11 @@ def sort_burst_sizes(sizes, levels=np.arange(1, 102, 20)):
     masks.append(sizes >= level2)
     return masks
 
+# plot per channel always
 def timetrace_fret(d, i=0, gamma=1., **kwargs):
     """Timetrace of burst FRET vs time. Uses `plot`."""
     b = d.mburst[i]
-    bsizes = bl.select_bursts.get_burst_size(d, ich=i, gamma=gamma)
+    bsizes = d.burst_sizes_ich(ich=i, gamma=gamma)
 
     style_kwargs = dict(marker='o', mew=0.5, color=blue, mec='grey',
                         alpha=0.4, ls='')
@@ -690,19 +692,20 @@ def timetrace_fret(d, i=0, gamma=1., **kwargs):
                  **style_kwargs)
     plt.plot(b.start*d.clk_p, d.E[i], '-k', alpha=0.1, lw=1)
     xlabel('Time (s)'); ylabel('E')
-    _gui_timetrace_burst_sel(d, i, timetrace_fret, gcf(), gca())
+    _gui_timetrace_burst_sel(d, gcf(), gca())
 
+# plot per channel always
 def timetrace_fret_scatter(d, i=0, gamma=1., **kwargs):
     """Timetrace of burst FRET vs time. Uses `scatter` (slow)."""
     b = d.mburst[i]
-    bsizes = d.burst_sizes_ich(d, ich=i, gamma=gamma)
+    bsizes = d.burst_sizes_ich(ich=i, gamma=gamma)
 
     style_kwargs = dict(s=bsizes, marker='o', alpha=0.5)
     style_kwargs.update(**kwargs)
     plt.scatter(b.start*d.clk_p, d.E[i], **style_kwargs)
     xlabel('Time (s)'); ylabel('E')
 
-
+# plot per channel always
 def timetrace_bg(d, i=0, nolegend=False, ncol=2, plot_style={}, show_da=False):
     """Timetrace of background rates."""
     bg = d.bg_from(Ph_sel('all'))
@@ -733,7 +736,7 @@ def timetrace_bg(d, i=0, nolegend=False, ncol=2, plot_style={}, show_da=False):
     plt.grid(True)
     plt.ylim(bottom=0)
 
-
+# plot per channel always
 def timetrace_b_rate(d, i=0):
     """Timetrace of bursts-per-second in each period."""
     t = arange(d.bg[i].size)*d.bg_time_s
@@ -748,11 +751,13 @@ def timetrace_b_rate(d, i=0):
     xlabel("Time (s)"); ylabel("Burst per second"); grid(True)
     plt.ylim(bottom=0)
 
+# plot per channel always
 def time_ph(d, i=0, num_ph=1e4, ph_istart=0):
     """Plot 'num_ph' ph starting at 'ph_istart' marking burst start/end.
     TODO: Update to use the new matplotlib eventplot.
     """
     b = d.mburst[i]
+    num_ph = int(num_ph)
     SLICE = slice(ph_istart, ph_istart+num_ph)
     ph_d = d.ph_times_m[i][SLICE][~d.A_em[i][SLICE]]
     ph_a = d.ph_times_m[i][SLICE][d.A_em[i][SLICE]]
@@ -779,7 +784,7 @@ def _bins_array(bins):
         bins = np.arange(*bins)
     return bins
 
-
+# not channel specific hidden function
 def _hist_burst_taildist(data, bins, pdf, weights=None, yscale='log',
                          color=None, label=None, plot_style=None, vline=None):
     hist = HistData(*np.histogram(data[~np.isnan(data)],
@@ -820,8 +825,11 @@ def hist_width(d, i=0, bins=(0, 10, 0.025), pdf=True, weights=None,
         vline (float): If not None, plot vertical line at the specified x
             position.
     """
-    weights = weights[i] if weights is not None else None
-    burst_widths = d.mburst[i].width * d.clk_p * 1e3
+    if i is None:
+        burst_widths = np.concatenate([mb.width for mb in d.mburst]) * d.clk_p * 1e3
+    else:
+        weights = weights[i] if weights is not None else None
+        burst_widths = d.mburst[i].width * d.clk_p * 1e3
 
     _hist_burst_taildist(burst_widths, bins, pdf, weights=weights, vline=vline,
                          yscale=yscale, color=color, plot_style=plot_style)
@@ -830,8 +838,8 @@ def hist_width(d, i=0, bins=(0, 10, 0.025), pdf=True, weights=None,
 
 
 def hist_brightness(d, i=0, bins=(0, 60, 1), pdf=True, weights=None,
-                    yscale='log', gamma=1, add_naa=False, beta=1.,
-                    donor_ref=True, add_aex=True, aex_corr=True,
+                    yscale='log', gamma=1, add_naa=False, ph_sel=Ph_sel('all'), beta=1.,
+                    donor_ref=True, naa_aexonly=False, naa_comp=False, na_comp=False,
                     label_prefix=None, color=None, plot_style=None, vline=None):
     """Plot histogram of burst brightness, i.e. burst size / duration.
 
@@ -845,12 +853,17 @@ def hist_brightness(d, i=0, bins=(0, 60, 1), pdf=True, weights=None,
         add_naa (bool): if True, include `naa` to the total burst size.
         donor_ref (bool): convention used for corrected burst size computation.
             See :meth:`fretbursts.burstlib.Data.burst_sizes_ich` for details.
-        add_aex (bool): *PAX-only*. Whether to add signal from Aex laser period
-            to the burst size. Default True.
-            See :meth:`fretbursts.burstlib.Data.burst_sizes_pax_ich`.
-        aex_corr (bool): *PAX-only*. If True, do duty-cycle correction
-            when adding the DAexAem term `naa`.
-            See :meth:`fretbursts.burstlib.Data.burst_sizes_pax_ich`.
+        na_comp (bool): **[PAX-only]** If True, multiply the `na` term
+            by `(1 + Wa/Wd)`, where Wa and Wd are the D and A alternation
+            durations (typically Wa/Wd = 1).
+        naa_aexonly (bool): **[PAX-only]** if True, the `naa` term is
+            corrected to include only A emission due to A excitation.
+            If False, the `naa` term includes all the counts in DAexAem.
+            The `naa` term also depends on the `naa_comp` argument.
+        naa_comp (bool): **[PAX-only]** If True, multiply the `naa` term by
+            `(1 + Wa/Wd)` where Wa and Wd are the D and A alternation
+            durations (typically Wa/Wd = 1). The `naa` term also depends on
+            the `naa_aexonly` argument.
         label_prefix (string or None): a custom prefix for the legend label.
         color (string or tuple or None): matplotlib color used for the plot.
         pdf (bool): if True, normalize the histogram to obtain a PDF.
@@ -863,10 +876,14 @@ def hist_brightness(d, i=0, bins=(0, 60, 1), pdf=True, weights=None,
     if plot_style is None:
         plot_style = {}
 
-    burst_widths = d.mburst[i].width * d.clk_p * 1e3
+    if i is None:
+        burst_widths = np.concatenate([mb.width for mb in d.mburst]) * d.clk_p * 1e3
+    else:
+        burst_widths = d.mburst[i].width * d.clk_p * 1e3
     sizes, label = _get_sizes_and_formula(
         d=d, ich=i, gamma=gamma, beta=beta, donor_ref=donor_ref,
-        add_naa=add_naa, add_aex=add_aex, aex_corr=aex_corr)
+        add_naa=add_naa, ph_sel=ph_sel, naa_aexonly=naa_aexonly,
+        naa_comp=naa_comp, na_comp=na_comp)
     brightness = sizes / burst_widths
     label = '$(' + label[1:-1] + ') / w$'
     if label_prefix is not None:
@@ -891,10 +908,17 @@ def _get_sizes_and_formula(d, ich, gamma, beta, donor_ref, add_naa,
     if 'PAX' in d.meas_type and ph_sel is not None:
         kws_pax = dict(ph_sel=ph_sel, naa_aexonly=naa_aexonly,
                        naa_comp=naa_comp, na_comp=na_comp)
-        sizes = d.burst_sizes_pax_ich(ich=ich, **dict(kws, **kws_pax))
+        if ich is None:
+            sizes = np.concatenate([d.burst_sizes_pax_ich(ich=i, **dict(kws, **kws_pax)) for i in range(d.nch)])
+        else:
+            sizes = d.burst_sizes_pax_ich(ich=ich, **dict(kws, **kws_pax))
         label = '$ %s $' % d._burst_sizes_pax_formula(**dict(kws, **kws_pax))
     else:
-        sizes = d.burst_sizes_ich(ich=ich, add_naa=add_naa, **kws)
+        if ich is None:
+            sizes = np.concatenate([d.burst_sizes_ich(ich=i, add_naa=add_naa, **kws) 
+                                    for i in range(d.nch)])
+        else:
+            sizes = d.burst_sizes_ich(ich=ich, add_naa=add_naa, **kws)
         label = label.format(FD='n_d', FA='n_a')
         if add_naa:
             corr = '(\\gamma\\beta) ' if donor_ref else '\\beta '
@@ -902,6 +926,7 @@ def _get_sizes_and_formula(d, ich, gamma, beta, donor_ref, add_naa,
     return sizes, label
 
 
+# dependent on _hist_burst_taildist
 def hist_size(d, i=0, which='all', bins=(0, 600, 4), pdf=False, weights=None,
               yscale='log', gamma=1, beta=1, donor_ref=True, add_naa=False,
               ph_sel=None, naa_aexonly=False, naa_comp=False, na_comp=False,
@@ -961,7 +986,7 @@ def hist_size(d, i=0, which='all', bins=(0, 600, 4), pdf=False, weights=None,
             add_naa=add_naa, ph_sel=ph_sel, naa_aexonly=naa_aexonly,
             naa_comp=naa_comp, na_comp=na_comp)
     else:
-        sizes = d[which][i]
+        sizes = np.concatenate(d[which]) if i is None else d[which][i]
         label = which
 
     # Use default label (with optional prefix) only if not explicitly
@@ -983,7 +1008,7 @@ def hist_size(d, i=0, which='all', bins=(0, 600, 4), pdf=False, weights=None,
     if legend:
         plt.legend(loc='upper right')
 
-
+# depends on  _hist_burst_taildist
 def hist_size_all(d, i=0, **kwargs):
     """Plot burst sizes for all the combinations of photons.
 
@@ -1152,10 +1177,10 @@ def hist_burst_data(
     fitter.histogram(binwidth=binwidth, bins=bins, verbose=verbose)
     if pdf:
         ylabel('PDF')
-        hist_vals = fitter.hist_pdf[i]
+        hist_vals = fitter.hist_pdf_tot if i is None else fitter.hist_pdf[i]
     else:
         ylabel('# Bursts')
-        hist_vals = fitter.hist_counts[i]
+        hist_vals = fitter.hist_counts_tot if i is None else fitter.hist_counts[i]
     xlabel(data_name)
     if data_name in ['E', 'S']:
         xlim(-0.19, 1.19)
@@ -1181,13 +1206,16 @@ def hist_burst_data(
         if pdf:
             scale = 1
         else:
-            scale = fitter.hist_binwidth * d.num_bursts[i]
+            if i is None:
+                scale = fitter.hist_binwidth * sum(d.num_bursts)
+            else:
+                scale = fitter.hist_binwidth * d.num_bursts[i]
 
     if show_model:
         model_plot_style_ = dict(color='k', alpha=0.8, label='Model')
         model_plot_style_.update(_normalize_kwargs(model_plot_style,
                                                    kind='line2d'))
-        fit_res = fitter.fit_res[i]
+        fit_res = fitter.fit_res_tot if i is None else fitter.fit_res[i]
         x = fitter.x_axis
         y = fit_res.model.eval(x=x, **fit_res.values)
         xx, yy = (y, x) if vertical else (x, y)
@@ -1213,7 +1241,10 @@ def hist_burst_data(
         xx, yy = (y, x) if vertical else (x, y)
         ax.plot(xx, yy, **kde_plot_style_)
     if show_kde_peak:
-        pline(fitter.kde_max_pos[i], ls='--', color='orange')
+        if i is None:
+            pline(fitter.kde_max_pos[-1], ls='--', color='orange')
+        else:
+            pline(fitter.kde_max_pos[i], ls='--', color='orange')
 
     if show_fit_value or show_fit_stats:
         if fit_from == 'kde':
@@ -1229,6 +1260,7 @@ def hist_burst_data(
         if show_fit_value:
             _plot_fit_text_ch(fit_arr, i, ax=ax)
 
+# depends on hist_burst_data
 def hist_fret(
         d, i=0, ax=None, binwidth=0.03, bins=None, pdf=True,
         hist_style='bar',
@@ -1257,6 +1289,7 @@ def hist_fret(
         model_plot_style=model_plot_style, kde_plot_style=kde_plot_style,
         verbose=verbose)
 
+# depends on hist_burst_data
 def hist_S(
         d, i=0, ax=None, binwidth=0.03, bins=None, pdf=True,
         hist_style='bar',
@@ -1284,6 +1317,7 @@ def hist_S(
         model_plot_style=model_plot_style, kde_plot_style=kde_plot_style,
         verbose=verbose)
 
+# should not depend on channel
 def _get_fit_text_stats(fit_arr, pylab=True):
     """Return a formatted string for mean E and max delta-E."""
     delta = (fit_arr.max() - fit_arr.min())*100
@@ -1291,6 +1325,7 @@ def _get_fit_text_stats(fit_arr, pylab=True):
     fit_text += r'\Delta E_{fit} = %.2f \%%' % delta
     if pylab: fit_text = r'$'+fit_text+r'$'
     return fit_text
+
 
 def _plot_fit_text_ch(
         fit_arr, ich, fmt_str="CH%d: $E_{fit} = %.3f$", ax=None,
@@ -1312,7 +1347,8 @@ def hist2d_alex(d, i=0, vmin=2, vmax=0, binwidth=0.05, S_max_norm=0.8,
     """
     ax = plt.gca()
     d._calc_alex_hist(binwidth)
-    ES_hist, E_bins, S_bins, S_ax = d.ES_hist[i], d.E_bins, d.S_bins, d.S_ax
+    ES_hist = np.sum(d.ES_hist, axis=0) if i is None else d.ES_hist[i]
+    E_bins, S_bins, S_ax = d.E_bins, d.S_bins, d.S_ax
 
     colormap = plt.get_cmap(cmap)
     # Heuristic for colormap range
@@ -1322,7 +1358,9 @@ def hist2d_alex(d, i=0, vmin=2, vmax=0, binwidth=0.05, S_max_norm=0.8,
         if vmax <= vmin: vmax = 10*vmin
 
     if scatter:
-        ax.plot(d.E[i], d.S[i], 'o', mew=0, ms=scatter_ms,
+        E = np.concatenate(d.E) if i is None else d.E[i]
+        S = np.concatenate(d.S) if i is None else d.S[i]
+        ax.plot(E, S, 'o', mew=0, ms=scatter_ms,
                 alpha=scatter_alpha, color=scatter_color)
     im = ax.imshow(ES_hist[:, ::-1].T, interpolation=interp,
                    extent=(E_bins[0], E_bins[-1], S_bins[0], S_bins[-1]),
@@ -1347,18 +1385,22 @@ def hexbin_alex(d, i=0, vmin=1, vmax=None, gridsize=80, cmap='Spectral_r',
                 E_name='E', S_name='S', **hexbin_kwargs):
     """Plot an hexbin 2D histogram for E-S.
     """
-    if d.num_bursts[i] < 1:
+    if i is None:
+        E, S = np.concatenate(d[E_name]), np.concatenate(d[S_name])
+    else:
+        E, S = d[E_name][i], d[S_name][i]
+    if E.size < 1:
         return
     hexbin_kwargs_ = dict(edgecolor='none', linewidth=0.2, gridsize=gridsize,
                           cmap=cmap, extent=(-0.2, 1.2, -0.2, 1.2), mincnt=1)
     if hexbin_kwargs is not None:
         hexbin_kwargs_.update(_normalize_kwargs(hexbin_kwargs))
-    poly = plt.hexbin(d[E_name][i], d[S_name][i], **hexbin_kwargs_)
+    poly = plt.hexbin(E, S, **hexbin_kwargs_)
     poly.set_clim(vmin, vmax)
     plt.xlabel('E')
     plt.ylabel('S')
 
-
+# channel independent
 def plot_ES_selection(ax, E1, E2, S1, S2, rect=True, **kwargs):
     """Plot an overlay ROI on top of an E-S plot (i.e. ALEX histogram).
 
@@ -1398,6 +1440,7 @@ def plot_ES_selection(ax, E1, E2, S1, S2, rect=True, **kwargs):
     ax.add_patch(ellips)
     return rect, ellips
 
+# channel independent
 def get_ES_range():
     """Get the range of ES histogram selected via GUI.
 
@@ -1408,7 +1451,6 @@ def get_ES_range():
         sel = hist2d_alex.gui_sel.selection
         print('E1={E1:.3}, E2={E2:.3}, S1={S1:.3}, S2={S2:.3}'.format(**sel))
     return sel
-
 
 def hist_interphoton_single(d, i=0, binwidth=1e-4, tmax=None, bins=None,
                             ph_sel=Ph_sel('all'), period=None,
@@ -1450,8 +1492,13 @@ def hist_interphoton_single(d, i=0, binwidth=1e-4, tmax=None, bins=None,
 
     # Compute interphoton delays
     if period is None:
-        ph_times = d.get_ph_times(ich=i, ph_sel=ph_sel)
+        if i is None:
+            ph_times = np.concatenate([d.get_ph_times(ich=j,ph_sel=ph_sel) for j in range(d.nch)])
+        else:
+            ph_times = d.get_ph_times(ich=i, ph_sel=ph_sel)
     else:
+        if i is None:
+            raise RuntimeError("Must specify channel/spot when specifying period")
         ph_times = d.get_ph_times_period(ich=i, period=period, ph_sel=ph_sel)
     delta_ph_t = np.diff(ph_times) * d.clk_p
     if tmax is None:
@@ -1538,7 +1585,8 @@ def hist_interphoton(d, i=0, binwidth=1e-4, tmax=None, bins=None, period=None,
             ph_sel_list.append(Ph_sel(Aex='Dem'))
 
     for ix, ph_sel in enumerate(ph_sel_list):
-        if not bl.mask_empty(d.get_ph_mask(i, ph_sel=ph_sel)):
+        sl = range(d.nch) if i is None else (i, )
+        if not np.all([bl.mask_empty(d.get_ph_mask(j, ph_sel=ph_sel)) for j in sl]):
             hist_interphoton_single(d, i=i, binwidth=binwidth, tmax=tmax,
                                     bins=bins, period=period, ph_sel=ph_sel,
                                     yscale=yscale, xscale=xscale, xunit=xunit,
@@ -1549,7 +1597,7 @@ def hist_interphoton(d, i=0, binwidth=1e-4, tmax=None, bins=None, period=None,
     if yscale == 'log' or xscale == 'log':
         _plot_status['hist_interphoton'] = {'autoscale': False}
 
-
+# TODO: condsider better method for displaying all channel, total bg histogram
 def hist_bg_single(d, i=0, binwidth=1e-4, tmax=0.01, bins=None,
                    ph_sel=Ph_sel('all'), period=0,
                    yscale='log', xscale='linear', xunit='ms', plot_style=None,
@@ -1642,31 +1690,63 @@ def hist_bg(d, i=0, binwidth=1e-4, tmax=0.01, bins=None, period=0,
 def hist_ph_delays(
         d, i=0, time_min_s=0, time_max_s=30, bin_width_us=10, mask=None,
         yscale='log', hfit_bin_ms=1, efit_tail_min_us=1000, **kwargs):
-    """Histog. of ph delays and comparison with 3 BG fitting functions.
+    """Histogram of ph delays and comparison with 3 BG fitting functions.
     """
-    ph = d.ph_times_m[i].copy()
-    if mask is not None: ph = ph[mask[i]]
-    ph = ph[(ph < time_max_s/d.clk_p)*(ph > time_min_s/d.clk_p)]
+    if i is None:
+        if mask is None:
+            mask = (slice(None) for _ in range(d.nch))
+        ph = (times[msk].copy() for times, msk in zip(d.ph_times_m, mask))
+        print("next")
+        if not isinstance(time_min_s, Iterable):
+            time_min_sg = (time_min_s for _ in range(d.nch))
+            print("next")
+        if not isinstance(time_max_s, Iterable):
+            time_max_sg = (time_max_s for _ in range(d.nch))
+            print("next")
+        ph = np.concatenate([p[(p < tmax/d.clk_p)*(p > tmin/d.clk_p)] 
+                             for p, tmax, tmin in zip(ph, time_max_sg, time_min_sg)])
+    else:
+        ph = d.ph_times_m[i].copy()
+        if mask is not None: 
+            ph = ph[mask[i]]
+        ph = ph[(ph < time_max_s/d.clk_p)*(ph > time_min_s/d.clk_p)]
     dph = np.diff(ph)*d.clk_p
     H = hist(dph*1e6, bins=r_[0:1200:bin_width_us], histtype='step', **kwargs)
     gca().set_yscale('log')
     xlabel(u'Ph delay time (μs)'); ylabel("# Ph")
+    F = 1 if 'normed' in kwargs else H[0].sum()*(bin_width_us)
 
     efun = lambda t, r: np.exp(-r*t)*r
-    re = bg.exp_fit(ph, tail_min_us=efit_tail_min_us)
-    rg = bg.exp_hist_fit(ph, tail_min_us=efit_tail_min_us, binw=hfit_bin_ms*1e3)
-    rc = bg.exp_cdf_fit(ph, tail_min_us=efit_tail_min_us)
+    try:
+        re = bg.exp_fit(ph, tail_min_us=efit_tail_min_us)[0]
+        re_do = True
+    except:
+        re_do = False
+    try:
+        rg = bg.exp_hist_fit(ph, tail_min_us=efit_tail_min_us, binw=hfit_bin_ms*1e-3)[0]
+        rg_do = True
+    except:
+        rg_do = False
+    try:
+        rc = bg.exp_cdf_fit(ph, tail_min_us=efit_tail_min_us)[0]
+        rc_do = True
+    except:
+        rc_do = False
     t = r_[0:1200]*1e-6
-    F = 1 if 'normed' in kwargs else H[0].sum()*(bin_width_us)
-    plot(t*1e6, 0.65*F*efun(t, rc)*1e-6, lw=3, alpha=0.5, color=purple,
-         label="%d cps - Exp CDF (tail_min_p=%.2f)" % (rc, efit_tail_min_us))
-    plot(t*1e6, 0.65*F*efun(t, re)*1e-6, lw=3, alpha=0.5, color=red,
-         label="%d cps - Exp ML (tail_min_p=%.2f)" % (re, efit_tail_min_us))
-    plot(t*1e6, 0.68*F*efun(t, rg)*1e-6, lw=3, alpha=0.5, color=green,
-         label=u"%d cps - Hist (bin_ms=%d) [Δ=%d%%]" % (hfit_bin_ms, rg,
-                                                        100*(rg-re)/re))
+    
+    if rc_do:
+        plot(t*1e6, 0.65*F*efun(t, rc)*1e-6, lw=3, alpha=0.5, color=purple,
+             label="%d cps - Exp CDF (tail_min_p=%.2f)" % (rc, efit_tail_min_us))
+    if re_do:
+        plot(t*1e6, 0.65*F*efun(t, re)*1e-6, lw=3, alpha=0.5, color=red,
+             label="%d cps - Exp ML (tail_min_p=%.2f)" % (re, efit_tail_min_us))
+    if re_do and rg_do:
+        plot(t*1e6, 0.68*F*efun(t, rg)*1e-6, lw=3, alpha=0.5, color=green,
+             label=u"%d cps - Hist (bin_ms=%d) [Δ=%d%%]" % (hfit_bin_ms, rg,
+                                                            100*(rg-re)/re))
     plt.legend(loc='best', fancybox=True)
 
+# TODO: update for concatenated data, probably fix bext.calc_mdelays_hist
 def hist_mdelays(d, i=0, m=10, bins_s=(0, 10, 0.02), period=0,
                  hold=False, bg_ppf=0.01, ph_sel=Ph_sel('all'), spline=True,
                  s=1., bg_fit=True, bg_F=0.8):
@@ -1677,9 +1757,15 @@ def hist_mdelays(d, i=0, m=10, bins_s=(0, 10, 0.02), period=0,
         #ax.clear()
         for _ind in range(len(ax.lines)): ax.lines.pop()
 
-    results = bext.calc_mdelays_hist(
-        d=d, ich=i, m=m, period=period, bins_s=bins_s,
-        ph_sel=ph_sel, bursts=True, bg_fit=bg_fit, bg_F=bg_F)
+    if i is None:
+        results = np.concatenate([bext.calc_mdelays_hist(d, ich=j, m=m, period=period, 
+                                                          bins_s=bins_s,ph_sel=ph_sel, 
+                                                          bursts=True, bg_fit=bg_fit, 
+                                                          bg_F=bg_F) 
+                                  for j in range(d.nch)])
+    else:
+        results = bext.calc_mdelays_hist(d, ich=i, m=m, period=period, bins_s=bins_s,
+                                         ph_sel=ph_sel, bursts=True, bg_fit=bg_fit, bg_F=bg_F)
     bin_x, histog_y = results[:2]
     bg_dist = results[2]
     rate_ch_kcps = 1./bg_dist.kwds['scale']  # extract the rate
@@ -1746,11 +1832,18 @@ def hist_mrates(d, i=0, m=10, bins=(0, 4000, 100), yscale='log', pdf=False,
                 dense=True, plot_style=None):
     """Histogram of m-photons rates. See also :func:`hist_mdelays`.
     """
-    ph = d.get_ph_times(ich=i)
-    if dense:
-        ph_mrates = 1.*m/((ph[m-1:]-ph[:ph.size-m+1])*d.clk_p*1e3)
+    if i is None:
+        ph = [d.get_ph_times(ich=j) for j in range(d.nch)]
+        if dense:
+            ph_mrates = np.concatenate([1.*m/(p[m-1:]-p[:p.size-m+1]*1e3*d.clk_p) for p in ph])
+        else:
+            ph_mrates = np.concatenate([1.*m/(np.diff(p[::m])*1e3*d.clk_p) for p in ph])
     else:
-        ph_mrates = 1.*m/(np.diff(ph[::m])*d.clk_p*1e3)
+        ph = d.get_ph_times(ich=i)
+        if dense:
+            ph_mrates = 1.*m/((ph[m-1:]-ph[:ph.size-m+1])*d.clk_p*1e3)
+        else:
+            ph_mrates = 1.*m/(np.diff(ph[::m])*d.clk_p*1e3)
 
     hist = HistData(*np.histogram(ph_mrates, bins=_bins_array(bins)))
     ydata = hist.pdf if pdf else hist.counts
@@ -1765,10 +1858,14 @@ def hist_sbr(d, i=0, bins=(0, 30, 1), pdf=True, weights=None, color=None,
              plot_style=None):
     """Histogram of per-burst Signal-to-Background Ratio (SBR).
     """
-    weights = weights[i] if weights is not None else None
+    if i is None:
+        weights = np.concatenate(weights) if weights is not None else None
+    else:
+        weights = weights[i] if weights is not None else None
     if 'sbr' not in d:
         d.calc_sbr()
-    _hist_burst_taildist(d.sbr[i], bins, pdf, weights=weights, color=color,
+    sbr = np.concatenate(d.sbr) if i is None else d.sbr[i]
+    _hist_burst_taildist(sbr, bins, pdf, weights=weights, color=color,
                          plot_style=plot_style)
     plt.xlabel('SBR')
 
@@ -1783,8 +1880,9 @@ def hist_burst_phrate(d, i=0, bins=(0, 1000, 20), pdf=True, weights=None,
     else:
         if 'max_rate' not in d:
             d.calc_max_rate(m=10)
-        max_rate = d.max_rate
-    _hist_burst_taildist(max_rate[i] * 1e-3, bins, pdf, weights=weights,
+        max_rate = np.concatenate(d.max_rate) if i is None else d.max_rate[i]
+    
+    _hist_burst_taildist(max_rate * 1e-3, bins, pdf, weights=weights,
                          color=color, plot_style=plot_style, vline=vline)
     plt.xlabel('Peak rate (kcps)')
 
@@ -1793,8 +1891,12 @@ def hist_burst_delays(d, i=0, bins=(0, 10, 0.2), pdf=False, weights=None,
                       color=None, plot_style=None):
     """Histogram of waiting times between bursts.
     """
-    weights = weights[i] if weights is not None else None
-    bdelays = np.diff(d.mburst[i].start*d.clk_p)
+    if i is None:
+        weights = np.concatenate(weights) if weights is not None else None
+        bdelays = np.concatenate([np.diff(mburst.start*d.clk_p) for mburst in d.mburst])
+    else:
+        weights = weights[i] if weights is not None else None
+        bdelays = np.diff(d.mburst[i].start*d.clk_p)
 
     _hist_burst_taildist(bdelays, bins, pdf, weights=weights, color=color,
                          plot_style=plot_style)
@@ -1802,10 +1904,13 @@ def hist_burst_delays(d, i=0, bins=(0, 10, 0.2), pdf=False, weights=None,
 
 ## Burst internal "symmetry"
 def hist_asymmetry(d, i=0, bin_max=2, binwidth=0.1, stat_func=np.median):
-    burst_asym = bext.asymmetry(d, ich=i, func=stat_func)
+    if i is None:
+        burst_asym = np.concatenate([bext.asymmetry(d, ich=j, func=stat_func) for j in range(d.nch)])
+    else:
+        burst_asym = bext.asymmetry(d, ich=i, func=stat_func)
     bins_pos = np.arange(0, bin_max+binwidth, binwidth)
     bins = np.hstack([-bins_pos[1:][::-1], bins_pos])
-    izero = (bins.size - 1)/2.
+    izero = int((bins.size - 1)/2)
     assert izero == np.where(np.abs(bins) < 1e-8)[0]
 
     counts, _ = np.histogram(burst_asym, bins=bins)
@@ -1832,69 +1937,105 @@ def hist_asymmetry(d, i=0, bin_max=2, binwidth=0.1, stat_func=np.median):
 
 def scatter_width_size(d, i=0):
     """Scatterplot of burst width versus size."""
-    b = d.mburst[i]
-    plot(b.width*d.clk_p*1e3, d.nt[i], 'o', mew=0, ms=3, alpha=0.7,
-         color='blue')
     t_ms = arange(0, 50)
-    plot(t_ms, ((d.m)/(d.T[i]))*t_ms*1e-3, '--', lw=2, color='k',
-         label='Slope = m/T = min. rate = %1.0f cps' % (d.m/d.T[i]))
-    plot(t_ms, d.bg_mean[Ph_sel('all')][i]*t_ms*1e-3, '--', lw=2, color=red,
+    if i is None:
+        b = np.concatenate([bb.width*d.clk_p*1e3 for bb in d.mburst])
+        nt = np.concatenate(d.nt)
+        T = np.average(d.T, weights=[ph.max()-ph.min() for ph in d.ph_times_m])
+        bg_mean = np.average(d.bg_mean[Ph_sel('all')], weights=[ph.max()-ph.min() for ph in d.ph_times_m])
+        bg_mean = bg_mean*t_ms*1e-3
+    else:
+        b = d.mburst[i].width*d.clk_p*1e3
+        nt = d.nt[i]
+        T = d.T[i]
+        bg_mean = d.bg_mean[Ph_sel('all')][i]*t_ms*1e-3
+    plot(b, nt, 'o', mew=0, ms=3, alpha=0.7,
+         color='blue')
+    
+    plot(t_ms, ((d.m)/(T))*t_ms*1e-3, '--', lw=2, color='k',
+         label='Slope = m/T = min. rate = %1.0f cps' % (d.m/T))
+    plot(t_ms, bg_mean, '--', lw=2, color=red,
          label='Noise rate: BG*t')
     xlabel('Burst width (ms)'); ylabel('Burst size (# ph.)')
     plt.xlim(0, 10); plt.ylim(0, 300)
     legend(frameon=False)
 
+
 def scatter_rate_da(d, i=0):
     """Scatter of nd rate vs na rate (rates for each burst)."""
-    b = d.mburst[i]
-    Rate = lambda nX: nX[i]/b.width/d.clk_p*1e-3
-    plot(Rate(d.nd), Rate(d.na), 'o', mew=0, ms=3, alpha=0.1, color='blue')
+    bw = np.concatenate([burst.width for burst in d.mburst]) if i is None else d.mburst[i].width
+    nd = np.concatenate(d.nd) if i is None else d.nd[i]
+    na = np.concatenate(d.na) if i is None else d.na[i]
+    Rate = lambda nX: nX/bw/d.clk_p*1e-3
+    plot(Rate(nd), Rate(na), 'o', mew=0, ms=3, alpha=0.1, color='blue')
     xlabel('D burst rate (kcps)'); ylabel('A burst rate (kcps)')
     plt.xlim(-20, 100); plt.ylim(-20, 100)
     legend(frameon=False)
+
 
 def scatter_fret_size(d, i=0, which='all', gamma=1, add_naa=False,
                       plot_style=None):
     """Scatterplot of FRET efficiency versus burst size.
     """
     if which == 'all':
-        size = d.burst_sizes_ich(ich=i, gamma=gamma, add_naa=add_naa)
+        if i is None:
+            size = np.concatenate([d.burst_sizes_ich(ich=j, gamma=gamma, add_naa=add_naa) 
+                                   for j in range(d.nch)])
+        else:
+            size = d.burst_sizes_ich(ich=i, gamma=gamma, add_naa=add_naa)
     else:
         assert which in d
-        size = d[which][i]
+        size = np.concatenate([d[which][j] for j in range(d.nch)]) if i is None else d[which][i]
 
     plot_style_ = dict(linestyle='', alpha=0.1, color=blue,
                        marker='o', markeredgewidth=0, markersize=3)
     plot_style_.update(_normalize_kwargs(plot_style, kind='line2d'))
-    plot(d.E[i], size, **plot_style_)
+    E = np.concatenate(d.E) if i is None else d.E[i]
+    plot(E, size, **plot_style_)
     xlabel("FRET Efficiency (E)")
     ylabel("Corrected Burst size (#ph)")
+
 
 def scatter_fret_nd_na(d, i=0, gamma=1., **kwargs):
     """Scatterplot of FRET versus gamma-corrected burst size."""
     default_kwargs = dict(mew=0, ms=3, alpha=0.3, color=blue)
     default_kwargs.update(**kwargs)
-    plot(d.E[i], gamma*d.nd[i]+d.na[i], 'o', **default_kwargs)
+    E = np.concatenate(d.E) if i is None else d.E[i]
+    nd = np.concatenate(d.nd) if i is None else d.nd[i]
+    na = np.concatenate(d.na) if i is None else d.na[i]
+    plot(E, gamma*nd+na, 'o', **default_kwargs)
     xlabel("FRET Efficiency (E)")
     ylabel("Burst size (#ph)")
 
+
 def scatter_fret_width(d, i=0):
     """Scatterplot of FRET versus burst width."""
-    b = d.mburst[i]
-    plot(d.E[i], (b[:, 1]*d.clk_p)*1e3, 'o', mew=0, ms=3, alpha=0.1,
+    if i is None:        
+        b = np.concatenate([mburst.width for mburst in d.mburst])*d.clk_p*1e3
+        E = np.concatenate(d.E)
+    else:
+        b = d.mburst[i].width*d.clk_p*1e3
+        E = d.E[i]
+    plot(E, b, 'o', mew=0, ms=3, alpha=0.1,
          color="blue")
     xlabel("FRET Efficiency (E)")
     ylabel("Burst width (ms)")
 
+
 def scatter_da(d, i=0, alpha=0.3):
     """Scatterplot of donor vs acceptor photons (nd, vs na) in each burst."""
-    plot(d.nd[i], d.na[i], 'o', mew=0, ms=3, alpha=alpha, color='blue')
+    nd = np.concatenate(d.nd) if i is None else d.nd[i]
+    na = np.concatenate(d.na) if i is None else d.na[i]
+    plot(nd, na, 'o', mew=0, ms=3, alpha=alpha, color='blue')
     xlabel('# donor ph.'); ylabel('# acceptor ph.')
     plt.xlim(-5, 200); plt.ylim(-5, 120)
 
+
 def scatter_naa_nt(d, i=0, alpha=0.5):
     """Scatterplot of nt versus naa."""
-    plot(d.nt[i], d.naa[i], 'o', mew=0, ms=3, alpha=alpha, color='blue')
+    nt = np.concatenate(d.nt) if i is None else d.nt[i]
+    naa = np.concatenate(d.naa) if i is None else d.naa[i]
+    plot(nt, naa, 'o', mew=0, ms=3, alpha=alpha, color='blue')
     plot(arange(200), color='k', lw=2)
     xlabel('Total burst size (nd+na+naa)'); ylabel('Accept em-ex BS (naa)')
     plt.xlim(-5, 200); plt.ylim(-5, 120)
@@ -1905,7 +2046,9 @@ def scatter_alex(d, i=0, **kwargs):
                       alpha=0.1)
     plot_style = _normalize_kwargs(plot_style, 'line2d')
     plot_style.update(_normalize_kwargs(kwargs, 'line2d'))
-    plot(d.E[i], d.S[i], 'o', **plot_style)
+    E = np.concatenate(d.E) if i is None else d.E[i]
+    S = np.concatenate(d.S) if i is None else d.S[i]
+    plot(E, S, 'o', **plot_style)
     xlabel("E"); ylabel('S')
     plt.xlim(-0.2, 1.2); plt.ylim(-0.2, 1.2)
 
@@ -2130,7 +2273,7 @@ def dplot(d, func, **kwargs):
         nch = d.shape[1]
     else:
         nch = d.nch
-    if nch == 1:
+    if "i" in kwargs or nch == 1:
         return dplot_1ch(d=d, func=func, **kwargs)
     elif nch <= 8:
         return dplot_8ch(d=d, func=func, **kwargs)
@@ -2265,6 +2408,9 @@ def alex_jointplot(d, i=0, gridsize=50, cmap='Spectral_r', kind='hex',
     ax_horiz = g.add_subplot(gs[0,0:3],sharex=ax_joint)
     ax_verti = g.add_subplot(gs[1:4,3],sharey=ax_joint)
     
+    E = np.concatenate(d[E_name]) if i is None else d[E_name][i]
+    S = np.concatenate(d[S_name]) if i is None else d[S_name][i]
+    
     if isinstance(marginal_color, int):
         histcolor = sns.color_palette(cmap, 100)[marginal_color]
     else:
@@ -2280,13 +2426,13 @@ def alex_jointplot(d, i=0, gridsize=50, cmap='Spectral_r', kind='hex',
         joint_kws_ = dict(s=40, color=histcolor, alpha=0.1, linewidths=0)
         if joint_kws is not None:
             joint_kws_.update(_normalize_kwargs(joint_kws))
-        jplot = ax_joint.scatter(d[E_name][i], d[S_name][i], **joint_kws_)
+        jplot = ax_joint.scatter(E, S, **joint_kws_)
     elif kind.startswith('hex'):
         joint_kws_ = dict(edgecolor='none', linewidth=0.2, gridsize=gridsize,
                           cmap=cmap, extent=(-0.2, 1.2, -0.2, 1.2), mincnt=1)
         if joint_kws is not None:
             joint_kws_.update(_normalize_kwargs(joint_kws))
-        jplot = ax_joint.hexbin(d[E_name][i], d[S_name][i], **joint_kws_)
+        jplot = ax_joint.hexbin(E, S, **joint_kws_)
 
         # Set the vmin and vmax values for the colormap
         if vmax is None:
@@ -2297,7 +2443,7 @@ def alex_jointplot(d, i=0, gridsize=50, cmap='Spectral_r', kind='hex',
                           cmap=cmap, clip=(-0.4, 1.4), bw=0.03)
         if joint_kws is not None:
             joint_kws_.update(_normalize_kwargs(joint_kws))
-        jplot = sns.kdeplot(x=d[E_name][0], y= d[S_name][0], ax=ax_joint, 
+        jplot = sns.kdeplot(x=E, y=S, ax=ax_joint, 
                             **joint_kws_)
     anno_str = ''
     for mburst in d.mburst:

--- a/fretbursts/burstlib_ext.py
+++ b/fretbursts/burstlib_ext.py
@@ -885,7 +885,8 @@ def group_data(d_list):
             raise RuntimeError("Inconsistent background estimation")
     new_d = Data(**dict(d_list[0]))
     new_d.add(nch = sum([d.nch for d in d_list]))
-    new_d.add(name = 'Joined data of\n' + '\n'.join(d.name for d in d_list))
+    new_d.add(name = 'Grouped data starting with ' + d_list[0].name)
+    new_d.add(fname = [d.fname for d in d_list])
     for field in ('_leakage', '_dir_ex', '_gamma', '_beta', 'clk_p'):
         if not np.all([np.allclose(d[field], new_d[field])  for d in d_list]):
             raise ValueError(f"Different {field} corrections, ensure data sets are technical repeats")

--- a/fretbursts/burstlib_ext.py
+++ b/fretbursts/burstlib_ext.py
@@ -887,7 +887,7 @@ def group_data(d_list):
     new_d.add(nch = sum([d.nch for d in d_list]))
     new_d.add(name = 'Joined data of\n' + '\n'.join(d.name for d in d_list))
     for field in ('_leakage', '_dir_ex', '_gamma', '_beta', 'clk_p'):
-        if np.any([d[field] != new_d[field] for d in d_list]):
+        if not np.all([np.allclose(d[field], new_d[field])  for d in d_list]):
             raise ValueError(f"Different {field} corrections, ensure data sets are technical repeats")
     if hasattr(d_list[0], 'nanotimes_params'):
         if not dict_equal(*[d.nanotimes_params[0] for d in d_list]):
@@ -896,7 +896,7 @@ def group_data(d_list):
         new_d.add(det_donor_accept=[l for l in chain.from_iterable(d.det_donor_accept for d in d_list)])
     # Check that burst metadata is also consistent, so analysis, if done conducted equally
     meta_data = dict()
-    for field in chain(Data.ph_fields, Data.burst_fields, Data.bg_fields, Data.burst_metadata):
+    for field in chain(Data.ph_fields, Data.burst_fields, Data.bg_fields, Data.burst_metadata, ('ph_times_t','det_t')):
         if hasattr(d_list[0], field):
             if np.any([not hasattr(d, field) for d in d_list[1:]]):
                 raise RuntimeError(f"Inconsistent analysis of {field}")

--- a/fretbursts/fit/exp_fitting.py
+++ b/fretbursts/fit/exp_fitting.py
@@ -140,8 +140,9 @@ def expon_fit_hist(s, bins, s_min=0, weights=None, offset=0.5,
     """
     if s_min > 0: s = s[s >= s_min] - s_min
     assert s.size > 10
-
+    
     counts, bins = np.histogram(s, bins=bins, density=True)
+    
     x = bins[:-1] + 0.5*(bins[1] - bins[0])  # bin center position
     y = counts
     x = x[y > 0]

--- a/fretbursts/fit/weighted_kde.py
+++ b/fretbursts/fit/weighted_kde.py
@@ -18,7 +18,7 @@ import numpy as np
 
 
 
-class gaussian_kde_w(object):
+class gaussian_kde_w:
     """
     Representation of a kernel-density estimate using Gaussian kernels.
 

--- a/fretbursts/loader.py
+++ b/fretbursts/loader.py
@@ -614,7 +614,7 @@ def _nsalex_apply_period_1ch(d, i, delete_ph_t=True):
 
     *See also:* :func:`alex_apply_period`.
     """
-    ich = 0   # we only support single-spot here
+    ich = i
     donor_ch, accept_ch = d._det_donor_accept_multich[ich]
     D_ON_multi, A_ON_multi = d._D_ON_multich[ich], d._A_ON_multich[ich]
     D_ON = [(D_ON_multi[i], D_ON_multi[i + 1])

--- a/fretbursts/mfit.py
+++ b/fretbursts/mfit.py
@@ -484,6 +484,7 @@ class MultiFitter:
         if fit_tot:
             data_sum = self.hist_pdf_tot if pdf else self.hist_counts_tot
             self.fit_res_tot = self.model.fit(data_sum, x=self.hist_axis, **fit_kwargs)
+            self.params_tot = pd.DataFrame(self.fit_res_tot.values, index=[0])
         self.fit_res = []
         # init_params = copy.deepcopy(self.model.params)
         for i, data in enumerate(data_list):

--- a/fretbursts/phtools/burstsearch.py
+++ b/fretbursts/phtools/burstsearch.py
@@ -118,7 +118,9 @@ def bsearch_py(times, L, m, T, slice_=None,
         # Correct burst-stop off by 1 when last burst does not finish
         i_stop += 1
         if i_stop - i_start + 1 >= L:
-            bursts.pop()
+            # check if the last burst was recorded, or if off-by one resulted in 1 less than necessary
+            if bursts[-1][0] == i_start:
+                bursts.pop()
             bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
 
     bursts = np.array(bursts, dtype='int64')
@@ -247,7 +249,7 @@ class BurstGap(namedtuple('BurstGap',
         return self.istop - self.istart + 1 - self.gap_counts
 
 
-class Bursts(object):
+class Bursts:
     """A container for burst data.
 
     This class provides a container for burst data. It has a

--- a/fretbursts/phtools/phrates.py
+++ b/fretbursts/phtools/phrates.py
@@ -30,7 +30,12 @@ Note:
 
 import numpy as np
 
-import phrates_c as cy
+try:
+    import phrates_c as cy
+except ImportError:
+    has_cython = False
+else:
+    has_cython = True
 try:
     from . import phrates_numba as nb
 except ImportError:

--- a/fretbursts/tests/test_burst_plot.py
+++ b/fretbursts/tests/test_burst_plot.py
@@ -1,0 +1,235 @@
+# Author: Paul David Harris
+# Purpose: Unit tests for burst_plot.py functions
+# Created: 13 Sept 2022
+"""
+Tests of plotting functions
+
+These are mostly smoke tests
+"""
+
+from collections import namedtuple
+from itertools import product
+import pytest
+import numpy as np
+
+
+try:
+    import matplotlib
+except ImportError:
+    has_matplotlib = False  # OK to run tests without matplotlib
+else:
+    has_matplotlib = True
+    matplotlib.use('Agg')  # but if matplotlib is installed, use Agg
+
+try:
+    import numba
+except ImportError:
+    has_numba = False
+else:
+    has_numba = True
+
+
+import fretbursts.background as bg
+import fretbursts.burstlib as bl
+import fretbursts.burstlib_ext as bext
+from fretbursts.burstlib import Data
+from fretbursts import loader
+from fretbursts import select_bursts
+from fretbursts.ph_sel import Ph_sel
+from fretbursts.phtools import phrates
+if has_matplotlib:
+    import fretbursts.burst_plot as bplt
+
+
+# data subdir in the notebook folder
+DATASETS_DIR = u'data/'
+
+
+def _alex_process(d):
+    loader.alex_apply_period(d)
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us=300)
+    d.burst_search(L=10, m=10, F=7)
+
+def load_dataset_1ch(process=True):
+    fn = "0023uLRpitc_NTP_20dT_0.5GndCl.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    if process:
+        _alex_process(d)
+    return d
+
+def load_dataset_1ch_nsalex(process=True):
+    fn = "dsdna_d7_d17_50_50_1.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    if process:
+        _alex_process(d)
+    return d
+
+def load_dataset_8ch():
+    fn = "12d_New_30p_320mW_steer_3.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us=300)
+    d.burst_search(L=10, m=10, F=7)
+    return d
+
+def load_fake_pax():
+    fn = "0023uLRpitc_NTP_20dT_0.5GndCl.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    d.add(ALEX=False, meas_type='PAX')
+    loader.alex_apply_period(d)
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us='auto')
+    d.burst_search(L=10, m=10, F=6, pax=True)
+    return d
+
+    
+def load_dataset_grouped(process=True):
+    fn = ['HP3_TE150_SPC630.hdf5', 'HP3_TE200_SPC630.hdf5', 'HP3_TE250_SPC630.hdf5', 'HP3_TE300_SPC630.hdf5']
+    fn = [DATASETS_DIR + f for f in fn]
+    d = loader.photon_hdf5(fn)
+    if process:
+        _alex_process(d)
+    return d
+
+
+@pytest.fixture(scope="module")
+def data_8ch(request):
+    d = load_dataset_8ch()
+    return d
+
+@pytest.fixture(scope="module")
+def data_1ch(request):
+    d = load_dataset_1ch()
+    return d
+
+@pytest.fixture(scope="module")
+def data_1ch_nsalex(request):
+    d = load_dataset_1ch_nsalex()
+    return d
+
+@pytest.fixture(scope="module")
+def data_grouped(request):
+    d = load_dataset_grouped()
+    return d
+
+@pytest.fixture(scope="module", params=[
+                                    load_dataset_1ch,
+                                    load_dataset_1ch_nsalex,
+                                    load_dataset_8ch,
+                                    load_dataset_grouped
+                                    ])
+def data(request):
+    load_func = request.param
+    d = load_func()
+    return d
+
+@pytest.fixture(scope="module", params=[
+                                    load_dataset_8ch,
+                                    load_dataset_grouped
+                                    ])
+def data_mch(request):
+    load_func = request.param
+    d = load_func()
+    return d
+
+@pytest.fixture(scope='module', params=[load_dataset_1ch,
+                                        load_dataset_1ch_nsalex,
+                                        load_dataset_grouped])
+def data_alex(request):
+    load_func = request.param
+    d = load_func()
+    return d
+
+##
+#  Multi-channel plot functions
+#
+
+def test_mch_plot_bg(data_mch):
+    d = data_mch
+    bplt.mch_plot_bg(d)
+
+def test_mch_plot_bg_ratio(data_mch):
+    d = data_mch
+    bplt.mch_plot_bg_ratio(d)
+
+def test_mch_plot_bsize(data_mch):
+    d = data_mch
+    bplt.mch_plot_bsize(d)
+
+##
+#  Timetrace plots
+#
+@pytest.fixture(scope='module', params = (bplt.timetrace_single, bplt.ratetrace_single,
+                                          bplt.hist_interphoton_single))
+def ratetraces(request):
+    return request.param
+
+def test_trace_single(data, ratetraces):
+    """Test plotting functions for time traces that do so on single Ph_sel"""
+    d = data
+    ph_sel_alex = (Ph_sel('all'), Ph_sel(Dex='Dem'), Ph_sel(Dex='Aem'), Ph_sel(Aex='Dem'), Ph_sel(Aex='Aem'))
+    ph_sel_single = (Ph_sel('all'), Ph_sel(Dex='Dem'), Ph_sel(Dex='Aem'))
+    ph_sel_list = ph_sel_alex if d.alternated else ph_sel_single
+    for i in range(d.nch):
+        for ph_sel in ph_sel_list:
+            bplt.dplot(d, ratetraces, i=i, ph_sel=ph_sel)
+
+@pytest.fixture(scope='module', params = (bplt.timetrace, bplt.ratetrace, 
+                                          bplt.timetrace_bg, bplt.timetrace_fret,
+                                          bplt.timetrace_fret_scatter, bplt.time_ph))
+def timetraces(request):
+    return request.param
+
+def test_trace(data, timetraces):
+    """Test general time trace type functions"""
+    d = data
+    for i in range(d.nch):
+            bplt.dplot(d, timetraces, i=i)
+
+
+@pytest.fixture(scope='module', params = (bplt.hist_size, bplt.hist_width,
+                                          bplt.hist_brightness, bplt.hist_size_all,
+                                          bplt.hist_fret, bplt.hist_interphoton,
+                                          bplt.hist_ph_delays, bplt.hist_mdelays,
+                                          bplt.hist_mrates, bplt.hist_sbr, 
+                                          bplt.hist_burst_phrate, bplt.hist_burst_delays,
+                                          bplt.hist_asymmetry))
+def hists(request):
+    return request.param
+
+def test_hist(data, hists):
+    d = data
+    bplt.dplot(d, hists, i=None)
+    for i in range(d.nch):
+        bplt.dplot(d, hists, i=i)
+
+def test_hist_S(data_alex):
+    d = data_alex
+    bplt.dplot(d, bplt.hist_S, i=None)
+    for i in range(d.nch):
+        bplt.dplot(d, bplt.hist_S)
+
+@pytest.fixture(scope='module', params = (bplt.hist2d_alex, bplt.hexbin_alex,
+                                          bplt.scatter_alex, bplt.scatter_naa_nt))
+def ES_plots(request):
+    return request.param
+
+def test_ES_plots(data_alex, ES_plots):
+    d = data_alex
+    bplt.dplot(d, ES_plots, i=None)
+    for i in range(d.nch):
+        bplt.dplot(d, ES_plots, i=i)
+
+@pytest.fixture(scope='module', params = (bplt.scatter_width_size, bplt.scatter_rate_da,
+                                          bplt.scatter_fret_size, bplt.scatter_fret_nd_na,
+                                          bplt.scatter_fret_width, bplt.scatter_da,))
+def scatterplots(request):
+    return request.param
+
+def test_scatterplots(data, scatterplots):
+    d = data
+    bplt.dplot(d, scatterplots, i=None)
+    for i in range(d.nch):
+        bplt.dplot(d, scatterplots, i=i)

--- a/fretbursts/tests/test_burstlib_ext.py
+++ b/fretbursts/tests/test_burstlib_ext.py
@@ -1,0 +1,232 @@
+# Author: Paul David Harris
+# Purpose: Unit tests for burstlib_ext.py functions
+# Created: 13 Sept 2022
+"""
+Unit tests for the burstlib_ext module (bext)
+
+Currently mostly just smoke tests
+
+Running tests requires pytest
+"""
+
+from collections import namedtuple
+from itertools import product
+import pytest
+import numpy as np
+
+
+try:
+    import matplotlib
+except ImportError:
+    has_matplotlib = False  # OK to run tests without matplotlib
+else:
+    has_matplotlib = True
+    matplotlib.use('Agg')  # but if matplotlib is installed, use Agg
+
+try:
+    import numba
+except ImportError:
+    has_numba = False
+else:
+    has_numba = True
+
+
+import fretbursts.background as bg
+import fretbursts.burstlib as bl
+import fretbursts.burstlib_ext as bext
+from fretbursts.burstlib import Data
+from fretbursts import loader
+from fretbursts import select_bursts
+from fretbursts.ph_sel import Ph_sel
+from fretbursts.phtools import phrates
+if has_matplotlib:
+    import fretbursts.burst_plot as bplt
+
+
+# data subdir in the notebook folder
+DATASETS_DIR = u'data/'
+
+
+def _alex_process(d):
+    loader.alex_apply_period(d)
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us=300)
+    d.burst_search(L=10, m=10, F=7)
+
+def load_dataset_1ch(process=True):
+    fn = "0023uLRpitc_NTP_20dT_0.5GndCl.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    if process:
+        _alex_process(d)
+    return d
+
+def load_dataset_1ch_nsalex(process=True):
+    fn = "dsdna_d7_d17_50_50_1.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    if process:
+        _alex_process(d)
+    return d
+
+def load_dataset_8ch():
+    fn = "12d_New_30p_320mW_steer_3.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us=300)
+    d.burst_search(L=10, m=10, F=7)
+    return d
+
+def load_fake_pax():
+    fn = "0023uLRpitc_NTP_20dT_0.5GndCl.hdf5"
+    fname = DATASETS_DIR + fn
+    d = loader.photon_hdf5(fname)
+    d.add(ALEX=False, meas_type='PAX')
+    loader.alex_apply_period(d)
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us='auto')
+    d.burst_search(L=10, m=10, F=6, pax=True)
+    return d
+
+def test_load_group():
+    """Smoke test to see if loading groupd data works"""
+    fn = ['HP3_TE150_SPC630.hdf5', 'HP3_TE200_SPC630.hdf5', 'HP3_TE250_SPC630.hdf5', 'HP3_TE300_SPC630.hdf5']
+    fn = [DATASETS_DIR + f for f in fn]
+    d = loader.photon_hdf5(fn)
+    assert d.nch == len(fn)
+    
+def load_dataset_grouped(process=True):
+    fn = ['HP3_TE150_SPC630.hdf5', 'HP3_TE200_SPC630.hdf5', 'HP3_TE250_SPC630.hdf5', 'HP3_TE300_SPC630.hdf5']
+    fn = [DATASETS_DIR + f for f in fn]
+    d = loader.photon_hdf5(fn)
+    if process:
+        _alex_process(d)
+    return d
+
+
+@pytest.fixture(scope="module")
+def data_8ch(request):
+    d = load_dataset_8ch()
+    return d
+
+@pytest.fixture(scope="module")
+def data_1ch(request):
+    d = load_dataset_1ch()
+    return d
+
+@pytest.fixture(scope="module")
+def data_1ch_nsalex(request):
+    d = load_dataset_1ch_nsalex()
+    return d
+
+@pytest.fixture(scope="module")
+def data_grouped(request):
+    d = load_dataset_grouped()
+    return d
+
+@pytest.fixture(scope="module", params=[
+                                    load_dataset_1ch,
+                                    load_dataset_1ch_nsalex,
+                                    load_dataset_8ch,
+                                    load_dataset_grouped
+                                    ])
+def data(request):
+    load_func = request.param
+    d = load_func()
+    return d
+
+@pytest.mark.parametrize("data_ch, process", product([load_dataset_1ch, 
+                                             load_dataset_1ch_nsalex, 
+                                             load_dataset_8ch],
+                                            [True, False]))
+def test_group_data(data_ch, process):
+    if data_ch is load_dataset_8ch:
+        orig_d = data_ch()
+    else:
+        orig_d = data_ch(process=process)
+    n = orig_d.nch
+    d = bext.group_data([orig_d for _ in range(8)])
+    assert n*8 == d.nch
+    for field in Data.ph_fields:
+        if hasattr(d, field):
+            assert len(d[field]) == 8*n, f"{field} not correct length"
+    if not process and orig_d.alternated:
+        loader.alex_apply_period(d)
+        for field in Data.ph_fields:
+            if hasattr(d, field):
+                assert len(d[field]) == 8*n, f"{field} not correct length"
+    d.calc_bg(bg.exp_fit, time_s=30, tail_min_us='auto')
+    d.burst_search(m=10, F=7, L=10)
+    for field in Data.burst_fields:
+        if hasattr(d, field):
+            assert len(d[field]) == 8*n, f'{field} not correct length'
+
+def test_join_data(data):
+    """Smoke test for bext.join_data() function.
+    """
+    d = data
+    dj = bext.join_data([d, d.copy()])
+    assert (dj.num_bursts == 2 * d.num_bursts).all()
+    for bursts in dj.mburst:
+        assert (np.diff(bursts.start) > 0).all()
+
+def test_burst_search_and_gate(data_1ch):
+    """Test consistency of burst search and gate."""
+    d = data_1ch
+    assert d.alternated
+
+    # Smoke tests
+    bext.burst_search_and_gate(d, F=(6, 8))
+    bext.burst_search_and_gate(d, m=(12, 8))
+    bext.burst_search_and_gate(d, min_rate_cps=(60e3, 40e3))
+    if d.nch > 1:
+        mr1 = 35e3 + np.arange(d.nch) * 1e3
+        mr2 = 30e3 + np.arange(d.nch) * 1e3
+        bext.burst_search_and_gate(d, min_rate_cps=(mr1, mr2))
+
+    # Consistency test
+    d_dex = d.copy()
+    d_dex.burst_search(ph_sel=Ph_sel(Dex='DAem'))
+    d_aex = d.copy()
+    d_aex.burst_search(ph_sel=Ph_sel(Aex='Aem'))
+    d_and = bext.burst_search_and_gate(d)
+    for bursts_dex, bursts_aex, bursts_and, ph in zip(
+            d_dex.mburst, d_aex.mburst, d_and.mburst, d.iter_ph_times()):
+        ph_b_mask_dex = bl.ph_in_bursts_mask(ph.size, bursts_dex)
+        ph_b_mask_aex = bl.ph_in_bursts_mask(ph.size, bursts_aex)
+        ph_b_mask_and = bl.ph_in_bursts_mask(ph.size, bursts_and)
+        assert (ph_b_mask_and == ph_b_mask_dex * ph_b_mask_aex).all()
+
+def test_burst_data(data):
+    """Test for bext.burst_data()"""
+    bext.burst_data(data, include_bg=True, include_ph_index=True)
+    bext.burst_data(data, include_bg=False, include_ph_index=True)
+    bext.burst_data(data, include_bg=True, include_ph_index=False)
+    bext.burst_data(data, include_bg=False, include_ph_index=False)
+
+
+
+
+def test_asymmetry(data):
+    d = data
+    for i in range(data.nch):
+        asym = bext.asymmetry(data, i, dropnan=False)
+        assert len(asym) == d.mburst[i].size
+        if np.any(np.isnan(asym)):
+            nan_count = np.isnan(asym).sum()
+            asym = bext.asymmetry(d, i)
+            assert len(asym) == d.mburst[i].size - nan_count
+
+
+def test_calc_mdelays_hist(data):
+    """Smoke test for calc_mdelays_hist"""
+    d = data
+    for i in range(d.nch):
+        for ph_sel in [Ph_sel('all'), Ph_sel(Dex='Dem'), Ph_sel(Dex='Aem')]:
+            bext.calc_mdelays_hist(d, ich=i)
+
+def test_burst_fitter(data):
+    d = data
+    bext.bursts_fitter(d)
+    assert hasattr(d, 'E_fitter')
+    if d.alternated:
+        bext.bursts_fitter(d, burst_data='S')
+        assert hasattr(d, 'S_fitter')

--- a/notebooks/Example - 2CDE Method.ipynb
+++ b/notebooks/Example - 2CDE Method.ipynb
@@ -430,7 +430,7 @@
     "                facecolor=sns.color_palette('Spectral_r', 100)[7])\n",
     "\n",
     "valid = np.isfinite(fret_2cde)\n",
-    "sns.kdeplot(ds.E[0][valid], fret_2cde[valid],\n",
+    "sns.kdeplot(x=ds.E[0][valid], y=fret_2cde[valid],\n",
     "            cmap='Spectral_r', shade=True, shade_lowest=False, n_levels=20)\n",
     "plt.xlabel('E', fontsize=16)\n",
     "plt.ylabel('FRET-2CDE', fontsize=16);\n",
@@ -617,9 +617,9 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python [conda env:fretbursts-dev]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-fretbursts-dev-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -631,7 +631,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.0"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - 2CDE Method.ipynb
+++ b/notebooks/Example - 2CDE Method.ipynb
@@ -617,7 +617,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -631,7 +631,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - Background estimation.ipynb
+++ b/notebooks/Example - Background estimation.ipynb
@@ -375,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/Example - Burst Variance Analysis.ipynb
+++ b/notebooks/Example - Burst Variance Analysis.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "dx=ds_FRET\n",
-    "alex_jointplot(dx)"
+    "alex_jointplot(dx);"
    ]
   },
   {
@@ -221,8 +221,8 @@
     "x = np.arange(0,1.01,0.01)\n",
     "y = np.sqrt((x*(1-x))/n)\n",
     "plt.plot(x, y, lw=2, color='k', ls='--')\n",
-    "im = sns.kdeplot(ds_FRET.E[0], np.asfarray(E_sub_std), \n",
-    "                 shade=True, cmap='Spectral_r', shade_lowest=False, n_levels=20)\n",
+    "im = sns.kdeplot(data={'E':ds_FRET.E[0], 'sigma':np.asfarray(E_sub_std)}, x='E', y='sigma', \n",
+    "                 fill=True, cmap='Spectral_r', thresh=0.05, levels=20)\n",
     "plt.xlim(0,1)\n",
     "plt.ylim(0,np.sqrt(0.5**2/7)*2)\n",
     "plt.xlabel('E', fontsize=16)\n",
@@ -244,7 +244,7 @@
     "                facecolor=sns.color_palette('Spectral_r', 100)[10])\n",
     "\n",
     "g = sns.JointGrid(x=x, y=y, ratio=3)\n",
-    "g.plot_joint(sns.kdeplot, cmap='Spectral_r', shade=True, shade_lowest=False, n_levels=20)\n",
+    "g.plot_joint(sns.kdeplot, cmap='Spectral_r', fill=True, thresh=0.05, levels=20)\n",
     "g.ax_marg_x.hist(x, bins=np.arange(-0.2, 1.2, 0.025), **hist_kws)\n",
     "g.ax_marg_y.hist(y, bins=50, orientation=\"horizontal\", **hist_kws)\n",
     "\n",
@@ -266,7 +266,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -280,7 +280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - Customize the us-ALEX histogram.ipynb
+++ b/notebooks/Example - Customize the us-ALEX histogram.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds)"
+    "alex_jointplot(ds);"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, vmax_fret=False)"
+    "alex_jointplot(ds, vmax_fret=False);"
    ]
   },
   {
@@ -141,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, vmax_fret=False, marginal_color=8)"
+    "alex_jointplot(ds, vmax_fret=False, marginal_color=8);"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, vmax_fret=False, marginal_color=7)"
+    "alex_jointplot(ds, vmax_fret=False, marginal_color=7);"
    ]
   },
   {
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, kind='kde')"
+    "alex_jointplot(ds, kind='kde');"
    ]
   },
   {
@@ -175,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, vmax=40)"
+    "alex_jointplot(ds, vmax=40);"
    ]
   },
   {
@@ -191,7 +191,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, cmap='plasma')"
+    "alex_jointplot(ds, cmap='plasma');"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, cmap='plasma', marginal_color=83)"
+    "alex_jointplot(ds, cmap='plasma', marginal_color=83);"
    ]
   },
   {
@@ -225,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, kind='scatter')"
+    "alex_jointplot(ds, kind='scatter');"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, kind='kde')"
+    "alex_jointplot(ds, kind='kde');"
    ]
   },
   {
@@ -245,7 +245,7 @@
    "source": [
     "dsf = ds.select_bursts(select_bursts.naa, th1=40)\n",
     "alex_jointplot(dsf, kind='kde',\n",
-    "               joint_kws={'shade': False, 'n_levels': 12, 'bw': 0.04})"
+    "               joint_kws={'fill': True, 'levels': 12, 'bw': 0.04});"
    ]
   },
   {
@@ -371,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds, marginal_kws={'show_kde': False})"
+    "alex_jointplot(ds, marginal_kws={'show_kde': False});"
    ]
   },
   {
@@ -448,7 +448,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -462,7 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - Exporting Burst Data Including Timestamps.ipynb
+++ b/notebooks/Example - Exporting Burst Data Including Timestamps.ipynb
@@ -764,7 +764,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -778,7 +778,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.6.13"
   },
   "nav_menu": {},
   "toc": {

--- a/notebooks/Example - FRET histogram fitting.ipynb
+++ b/notebooks/Example - FRET histogram fitting.ipynb
@@ -298,7 +298,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -312,7 +312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - Plotting timetraces with bursts.ipynb
+++ b/notebooks/Example - Plotting timetraces with bursts.ipynb
@@ -159,9 +159,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:fretbursts-dev]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-fretbursts-dev-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -173,7 +173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - Selecting FRET populations.ipynb
+++ b/notebooks/Example - Selecting FRET populations.ipynb
@@ -98,7 +98,7 @@
     "ds_fret = ds_no_Aonly.select_bursts(select_bursts.naa, th1=30)\n",
     "\n",
     "alex_jointplot(ds)\n",
-    "alex_jointplot(ds_fret)"
+    "alex_jointplot(ds_fret);"
    ]
   },
   {
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "ds_fret_2 = d_fret_2.select_bursts(select_bursts.size, th1=30)\n",
-    "alex_jointplot(ds_fret_2)"
+    "alex_jointplot(ds_fret_2);"
    ]
   },
   {
@@ -177,22 +177,15 @@
    "outputs": [],
    "source": [
     "ds_fret_22 = d_fret_22.select_bursts(select_bursts.size, th1=30)\n",
-    "alex_jointplot(ds_fret_22)"
+    "alex_jointplot(ds_fret_22);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:fretbursts-dev]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-fretbursts-dev-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -204,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example - Working with timestamps and bursts.ipynb
+++ b/notebooks/Example - Working with timestamps and bursts.ipynb
@@ -672,7 +672,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -686,7 +686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.13"
   },
   "toc": {
    "colors": {

--- a/notebooks/Example- Combining Technical Repeats.ipynb
+++ b/notebooks/Example- Combining Technical Repeats.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "58b73b78",
+   "metadata": {},
+   "source": [
+    "# Example: Combining Technical Repeats into Single Data object\n",
+    "\n",
+    "You can now store multiple technical repeats into a single data object.\n",
+    "\n",
+    "> **Note**:\n",
+    "> You can combine any two hdf5 files into technical repeats so long as their base acquisition parameters are the same.\n",
+    "> In this example we will use 4 different files, which are not actually technical repeats.\n",
+    "> This is for demonstration purposes, in general, you should only combine files that are actually acquired with the same sample and measuremtn parameters.\n",
+    "\n",
+    "So first let's import FRETBursts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d144fba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fretbursts import *\n",
+    "sns = init_notebook(apionly=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f49a1da3",
+   "metadata": {},
+   "source": [
+    "Now we download the files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47a95281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = ['https://zenodo.org/record/5902313/files/HP3_TE150_SPC630.hdf5',\n",
+    "        'https://zenodo.org/record/5902313/files/HP3_TE200_SPC630.hdf5',\n",
+    "        'https://zenodo.org/record/5902313/files/HP3_TE250_SPC630.hdf5',\n",
+    "        'https://zenodo.org/record/5902313/files/HP3_TE300_SPC630.hdf5']\n",
+    "for url in urls:\n",
+    "    download_file(url, save_dir='./data')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b27535d6",
+   "metadata": {},
+   "source": [
+    "## Loading muliple photon-HDF5 files\n",
+    "\n",
+    "To load mutliple files into a single data object (as technical repeats), simple provide the filenames as a list to `loader.photon_hdf5()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38cbd342",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filenames = [\"data/HP3_TE150_SPC630.hdf5\", \n",
+    "             \"data/HP3_TE200_SPC630.hdf5\", \n",
+    "             \"data/HP3_TE250_SPC630.hdf5\", \n",
+    "             \"data/HP3_TE300_SPC630.hdf5\"]\n",
+    "d = loader.photon_hdf5(filenames)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ff5c9cf",
+   "metadata": {},
+   "source": [
+    "Now the rest of the analysis can proceed, what you do to one technical repeat, you do to the other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6230e45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader.alex_apply_period(d)\n",
+    "d.calc_bg(bg.exp_fit, time_s=1000, tail_min_us=(800, 4000, 1500, 1000, 3000))\n",
+    "d.burst_search(L=10, m=10, F=6)\n",
+    "ds = d.select_bursts(select_bursts.size, add_naa=True, th1=30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09236ac7",
+   "metadata": {},
+   "source": [
+    "The technical repeats are stored like separate spots in a multi-spot experiment, so now if you want to look at the E-values of a given repeat, it looks like `d.E[i]` where `i` is the index of the repeat in the data, as you supplied it to `loader.photon_hdf5`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2fe0787",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.E"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3c69093",
+   "metadata": {},
+   "source": [
+    "When you plot with `dplot()` the default will be to display each separately, in a 8-channel plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a40f648",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dplot(ds, hist2d_alex)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aba26b56",
+   "metadata": {},
+   "source": [
+    "If you want to plot the combined results, just add the keyword argument `i=None`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a07bb81f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dplot(ds, hist2d_alex, i=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9538bc71",
+   "metadata": {},
+   "source": [
+    "The fitter objects also now fit not just individual repeats, but the entire concatenated set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21b860ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "E_fitter = bext.bursts_fitter(ds, 'E', binwidth=0.03)\n",
+    "model = mfit.factory_two_gaussians()\n",
+    "E_fitter.fit_histogram(model=model, pdf=False, method='leastsq')\n",
+    "dplot(ds, hist_fret, show_model=True, pdf=False, i=0);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c60f829",
+   "metadata": {},
+   "source": [
+    "Finally, in the fitter object, new attributes have been added, basically, if there is a per-channel parameter, then the same name with `_tot` added to the end will contain the summed counts, pdf, or fitting object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "539904a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "E_fitter.fit_res_tot"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/FRETBursts - 8-spot smFRET burst analysis.ipynb
+++ b/notebooks/FRETBursts - 8-spot smFRET burst analysis.ipynb
@@ -594,19 +594,12 @@
     "> On the contrary the 2-Gaussians histogram fit tends to follows \n",
     "> more the peak position an less the \"asymmetric\" tails.  "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -620,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/FRETBursts - ns-ALEX example.ipynb
+++ b/notebooks/FRETBursts - ns-ALEX example.ipynb
@@ -280,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds)"
+    "alex_jointplot(ds);"
    ]
   },
   {
@@ -298,7 +298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alex_jointplot(ds)"
+    "alex_jointplot(ds);"
    ]
   },
   {
@@ -495,39 +495,11 @@
    "source": [
     "When loaded in MATLAB the arrays will be named `bn_t`, `bn_d` and `bn_a`."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -541,7 +513,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/FRETBursts - us-ALEX smFRET burst analysis.ipynb
+++ b/notebooks/FRETBursts - us-ALEX smFRET burst analysis.ipynb
@@ -1897,18 +1897,11 @@
     "\n",
     "*Please send feedback and/or question by opening a new [GitHub Issue](https://github.com/OpenSMFS/FRETBursts/issues).*"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1922,7 +1915,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This update adds tests for most burst plotting functions, and expands test for burstlib_ext.

The major addition is that `dplot(data, func, i=None)` now plots data concatenated from technical repeats.

Technical repeats can now be treated in a single `data` object, which can be created by calling `data = loader.photon_hdf5([filename1, filename2 ...])` Or processed data object can be merged with the `bext.group_data([data1, data2 ...])` function. In both cases, technical repeats are treated like different spots in a multi-spot experiment.