### PR TITLE
Replace np.asfarray

### DIFF
--- a/fretbursts/bg_cache.py
+++ b/fretbursts/bg_cache.py
@@ -197,7 +197,7 @@ def _load_bg_data(d, bg_calc_kwargs, h5file):
     for node in bg_group._f_iter_nodes():
         if node._v_name.startswith('BG_'):
             ph_sel = Ph_sel.from_str(node._v_name[len('BG_'):])
-            bg[ph_sel] = [np.asfarray(b) for b in node.read()]
+            bg[ph_sel] = [np.asarray(b, dtype=np.float64) for b in node.read()]
 
     Lim = bg_group.Lim.read()
     Ph_p = bg_group.Ph_p.read()

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -222,7 +222,7 @@ def burst_ph_stats(ph_data, bursts, func=np.mean, func_kw=None, **kwargs):
     burst_stats = []
     for burst_ph in iter_bursts_ph(ph_data, bursts, **kwargs):
         burst_stats.append(func(burst_ph, **func_kw))
-    return np.asfarray(burst_stats)  # NOTE: asfarray converts None to nan
+    return np.asarray(burst_stats, dtype=np.float64)  # NOTE: asfarray converts None to nan
 
 
 def ph_in_bursts_mask(ph_data_size, bursts):
@@ -2629,7 +2629,7 @@ class Data(DataContainer):
         """Apply/update leakage (or bleed-through) correction.
         """
         assert (np.size(leakage) == 1) or (np.size(leakage) == self.nch)
-        self.add(_leakage=np.asfarray(leakage), leakage_corrected=True)
+        self.add(_leakage=np.asarray(leakage, dtype=np.float64), leakage_corrected=True)
         self._update_corrections()
 
     @property
@@ -2679,7 +2679,7 @@ class Data(DataContainer):
         """Change the `chi_ch` value and recompute E and S."""
         msg = 'chi_ch is a per-channel correction and must have size == nch.'
         assert np.size(chi_ch) == self.nch, ValueError(msg)
-        self.add(_chi_ch=np.asfarray(chi_ch))
+        self.add(_chi_ch=np.asarray(chi_ch, dtype=np.float64))
         if 'mburst' in self:
             # Recompute E and S and delete fitter objects
             self.calc_fret(corrections=False, pax=self.pax)
@@ -2697,7 +2697,7 @@ class Data(DataContainer):
     def _update_gamma(self, gamma):
         """Change the `gamma` value and recompute E and S."""
         assert (np.size(gamma) == 1) or (np.size(gamma) == self.nch)
-        self.add(_gamma=np.asfarray(gamma))
+        self.add(_gamma=np.asarray(gamma, dtype=np.float64))
         if 'mburst' in self:
             # Recompute E and S and delete fitter objects
             self.calc_fret(corrections=False, pax=self.pax)

--- a/fretbursts/burstlib_ext.py
+++ b/fretbursts/burstlib_ext.py
@@ -248,7 +248,7 @@ def calc_bg_brute_cache(dx, min_ph_delay_list=None, return_all=False,
     if min_ph_delay_list is None:
         min_ph_delay_list = np.arange(100, 8500, 100)
     else:
-        min_ph_delay_list = np.asfarray(min_ph_delay_list)
+        min_ph_delay_list = np.asarray(min_ph_delay_list, dtype=np.float64)
 
     base_name = 'bg_%s_%ds_%s/' % (dx.bg_fun_name, dx.bg_time_s, error_metrics)
     store_fname = dx.fname[:-5] + '_BKG.hdf5'
@@ -301,7 +301,7 @@ def calc_bg_brute(dx, min_ph_delay_list=None, return_all=False,
     if min_ph_delay_list is None:
         min_ph_delay_list = np.arange(100, 8500, 100)
     else:
-        min_ph_delay_list = np.asfarray(min_ph_delay_list)
+        min_ph_delay_list = np.asarray(min_ph_delay_list, dtype=np.float64)
 
     ph_sel_labels = [str(p) for p in dx.ph_streams]
 

--- a/fretbursts/exptools.py
+++ b/fretbursts/exptools.py
@@ -45,10 +45,10 @@ significance = [15, 10, 5, 2.5, 1]
 
 
 def weighted_median(data, weights=None):
-    data = np.asfarray(data)
+    data = np.asarray(data, dtype=np.float64)
     if weights is None:
         return np.median(data)
-    weights = np.asfarray(weights)
+    weights = np.asarray(weights, dtype=np.float64)
     data_argsort = data.argsort()
     sorted_data = data[data_argsort]
     sorted_weights = weights[data_argsort]

--- a/fretbursts/phtools/burstsearch.py
+++ b/fretbursts/phtools/burstsearch.py
@@ -182,7 +182,7 @@ def mch_count_ph_in_bursts_py(Mburst, Mask):
         A list of 1D array, each containing the number of photons
         in each burst counting only photons in the selection mask.
     """
-    return [np.asfarray(count_ph_in_bursts(bursts, mask))
+    return [np.asarray(count_ph_in_bursts(bursts, mask), dtype=np.float64)
             for bursts, mask in zip(Mburst, Mask)]
 
 

--- a/fretbursts/phtools/burstsearch_c.pyx
+++ b/fretbursts/phtools/burstsearch_c.pyx
@@ -129,5 +129,5 @@ def mch_count_ph_in_bursts_c(mburst, masks):
     num_ph_list = []
     for bursts, mask in zip(mburst, masks):
         num_ph_list.append(
-            np.asfarray(count_ph_in_bursts_c(bursts.data, mask.view(np.uint8))))
+            np.asarray(count_ph_in_bursts_c(bursts.data, mask.view(np.uint8)), dtype=np.float64))
     return num_ph_list

--- a/notebooks/Example - Burst Variance Analysis.ipynb
+++ b/notebooks/Example - Burst Variance Analysis.ipynb
@@ -221,7 +221,7 @@
     "x = np.arange(0,1.01,0.01)\n",
     "y = np.sqrt((x*(1-x))/n)\n",
     "plt.plot(x, y, lw=2, color='k', ls='--')\n",
-    "im = sns.kdeplot(data={'E':ds_FRET.E[0], 'sigma':np.asfarray(E_sub_std)}, x='E', y='sigma', \n",
+    "im = sns.kdeplot(data={'E':ds_FRET.E[0], 'sigma':np.asarray(E_sub_std, dtype=np.float64)}, x='E', y='sigma', \n",
     "                 fill=True, cmap='Spectral_r', thresh=0.05, levels=20)\n",
     "plt.xlim(0,1)\n",
     "plt.ylim(0,np.sqrt(0.5**2/7)*2)\n",
@@ -239,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x, y = ds_FRET.E[0], np.asfarray(E_sub_std)\n",
+    "x, y = ds_FRET.E[0], np.asarray(E_sub_std, dtype=np.float64)\n",
     "hist_kws = dict(edgecolor='k', linewidth=0.2,\n",
     "                facecolor=sns.color_palette('Spectral_r', 100)[10])\n",
     "\n",


### PR DESCRIPTION
Replaced np.asfarray(a) with np.asarray(a, dtype=np.float64) as required in numpy v2.0.0. See https://github.com/numpy/numpy/releases/tag/v2.0.0.